### PR TITLE
fix: do not start pulsar app automatically

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,8 @@ defmodule OffBroadwayPulsar.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      included_applications: [:pulsar]
     ]
   end
 


### PR DESCRIPTION
### Description

Do not start `pulsar-elixir` automatically. Let the parent application decide when and how to start it.