### PR TITLE
fix: pipeline stops on consumer restart

### DIFF
--- a/lib/off_broadway/pulsar/consumer.ex
+++ b/lib/off_broadway/pulsar/consumer.ex
@@ -4,6 +4,9 @@ defmodule OffBroadway.Pulsar.Consumer do
 
   @impl true
   def init([broadway_producer]) do
+    # Notify producer that consumer is ready and needs initial flow
+    # This is sent on first startup AND on every consumer restart
+    send(broadway_producer, {:consumer_ready, self()})
     {:ok, %{broadway_producer: broadway_producer}}
   end
 

--- a/lib/off_broadway/pulsar/producer.ex
+++ b/lib/off_broadway/pulsar/producer.ex
@@ -37,9 +37,6 @@ defmodule OffBroadway.Pulsar.Producer do
   @default_flow_threshold 50
   @default_flow_refill 50
 
-  # Initial flow delay to wait for consumer async initialization
-  @initial_flow_delay_ms 5000
-
   @doc """
   Starts an `OffBroadway.Pulsar` producer process linked to the current
   process.
@@ -187,6 +184,7 @@ defmodule OffBroadway.Pulsar.Producer do
 
     state = %{
       consumer_group: consumer_group,
+      consumer_pid: nil,
       demand: 0,
       buffer: [],
       flow_initial: flow_initial,
@@ -194,11 +192,6 @@ defmodule OffBroadway.Pulsar.Producer do
       flow_refill: flow_refill,
       outstanding_permits: 0
     }
-
-    # Defer initial flow control to allow consumer to complete async initialization
-    # The consumer starts asynchronously with handle_continue and has startup delays:
-    # startup_delay_ms (default 1000ms) + startup_jitter_ms (default 1000ms) + subscribe/seek time
-    Process.send_after(self(), :send_initial_flow, 0)
 
     {:producer, state}
   end
@@ -213,26 +206,21 @@ defmodule OffBroadway.Pulsar.Producer do
   end
 
   @impl GenStage
-  def handle_info(:send_initial_flow, state) do
-    # We wait @initial_flow_delay_ms to ensure consumer is ready
-    Process.sleep(@initial_flow_delay_ms)
-    # Send initial flow control permits after consumer is ready
-    # Get current consumer PID dynamically in case it has restarted
-    case get_consumer_pid(state.consumer_group) do
-      {:ok, consumer_pid} ->
-        case Pulsar.Consumer.send_flow(consumer_pid, state.flow_initial) do
-          :ok ->
-            Logger.debug("Sent initial flow of #{state.flow_initial} permits to Pulsar consumer")
-            {:noreply, [], %{state | outstanding_permits: state.flow_initial}}
+  def handle_info({:consumer_ready, consumer_pid}, state) do
+    Logger.debug("Consumer #{inspect(consumer_pid)} is ready, sending initial flow of #{state.flow_initial} permits")
 
-          {:error, reason} ->
-            Logger.error("Failed to send initial flow: #{inspect(reason)}")
-            {:noreply, [], state}
-        end
+    case Pulsar.Consumer.send_flow(consumer_pid, state.flow_initial) do
+      :ok ->
+        Logger.debug("Sent initial flow of #{state.flow_initial} permits to consumer #{inspect(consumer_pid)}")
+
+        # Reset permits to initial flow (handles both first start and restart)
+        {:noreply, [], %{state | consumer_pid: consumer_pid, outstanding_permits: state.flow_initial}}
 
       {:error, reason} ->
-        Logger.error("Failed to get consumer PID: #{inspect(reason)}")
-        {:noreply, [], state}
+        Logger.error("Failed to send initial flow to consumer #{inspect(consumer_pid)}: #{inspect(reason)}")
+
+        # Don't crash producer, consumer will retry or supervisor will handle it
+        {:noreply, [], %{state | consumer_pid: consumer_pid}}
     end
   end
 
@@ -255,17 +243,11 @@ defmodule OffBroadway.Pulsar.Producer do
     {:noreply, [], %{state | demand: demand}}
   end
 
-  defp dispatch_messages(%{buffer: buffer, demand: demand, consumer_group: consumer_group} = state) do
+  defp dispatch_messages(%{buffer: buffer, demand: demand, consumer_pid: consumer_pid} = state) do
     {to_dispatch, remaining} = Enum.split(buffer, demand)
 
-    # Get current consumer PID for acknowledger
-    consumer_pid =
-      case get_consumer_pid(consumer_group) do
-        {:ok, pid} -> pid
-        # Will fail on ACK, but let message through
-        {:error, _} -> nil
-      end
-
+    # Use tracked consumer PID for acknowledger
+    # If consumer_pid is nil, messages will fail on ACK, but we let them through
     broadway_messages = Enum.map(to_dispatch, &wrap_message(&1, consumer_pid))
     Logger.debug("Dispatching #{length(to_dispatch)} messages, #{length(remaining)} remaining in buffer")
 
@@ -303,40 +285,24 @@ defmodule OffBroadway.Pulsar.Producer do
     threshold = state.flow_threshold
     refill_amount = state.flow_refill
 
-    if outstanding <= threshold do
-      # Get current consumer PID dynamically in case it has restarted
-      case get_consumer_pid(state.consumer_group) do
-        {:ok, consumer_pid} ->
-          case Pulsar.Consumer.send_flow(consumer_pid, refill_amount) do
-            :ok ->
-              new_outstanding = outstanding + refill_amount
+    if outstanding <= threshold and state.consumer_pid != nil do
+      # Use tracked consumer PID
+      case Pulsar.Consumer.send_flow(state.consumer_pid, refill_amount) do
+        :ok ->
+          new_outstanding = outstanding + refill_amount
 
-              Logger.debug(
-                "Refilled flow window: #{refill_amount} permits (outstanding: #{outstanding} → #{new_outstanding})"
-              )
+          Logger.debug(
+            "Refilled flow window: #{refill_amount} permits (outstanding: #{outstanding} → #{new_outstanding})"
+          )
 
-              %{state | outstanding_permits: new_outstanding}
-
-            {:error, reason} ->
-              Logger.error("Failed to refill flow window: #{inspect(reason)}")
-              state
-          end
+          %{state | outstanding_permits: new_outstanding}
 
         {:error, reason} ->
-          Logger.error("Failed to get consumer PID for refill: #{inspect(reason)}")
+          Logger.error("Failed to refill flow window: #{inspect(reason)}")
           state
       end
     else
       state
-    end
-  end
-
-  # Gets the current consumer PID from the consumer group
-  # This is called dynamically to handle consumer restarts
-  defp get_consumer_pid(consumer_group) do
-    case Pulsar.get_consumers(consumer_group) do
-      [consumer_pid | _] -> {:ok, consumer_pid}
-      [] -> {:error, :no_consumers}
     end
   end
 


### PR DESCRIPTION
## Description

This pull request implements a more reactive initialization process of the Broadway producer.

The callback module of the consumer has been updated to notify the producer once it's ready (ie. upon a successful connection to the Pulsar broker and subscription to the configured topic). The producer now listens for this notification and relies on it as a trigger to initiate the flow-control process.

This implementation improves upon the previous one, since it doesn't rely on hard-coded wait intervals, etc. and also works when consumer processes get restarted by their supervisor.