### PR TITLE
fix: Inherit default callbacks for Pulsar consumer

### DIFF
--- a/lib/off_broadway/pulsar/consumer.ex
+++ b/lib/off_broadway/pulsar/consumer.ex
@@ -1,6 +1,6 @@
 defmodule OffBroadway.Pulsar.Consumer do
   @moduledoc false
-  @behaviour Pulsar.Consumer.Callback
+  use Pulsar.Consumer.Callback
 
   @impl true
   def init([broadway_producer, topic]) do

--- a/test/off_broadway/pulsar/consumer_test.exs
+++ b/test/off_broadway/pulsar/consumer_test.exs
@@ -1,0 +1,35 @@
+defmodule OffBroadway.Pulsar.ConsumerTest do
+  use ExUnit.Case, async: true
+
+  alias OffBroadway.Pulsar.Consumer
+
+  describe "terminate/2" do
+    test "is defined and returns :ok" do
+      assert Consumer.terminate(:normal, %{}) == :ok
+    end
+
+    test "is defined for any reason and state" do
+      assert Consumer.terminate(:shutdown, %{broadway_producer: self(), topic: "t"}) == :ok
+      assert Consumer.terminate({:shutdown, :reason}, nil) == :ok
+    end
+  end
+
+  describe "handle_call/3" do
+    test "returns not_implemented error by default" do
+      assert Consumer.handle_call(:anything, {self(), :tag}, %{}) ==
+               {:reply, {:error, :not_implemented}, %{}}
+    end
+  end
+
+  describe "handle_cast/2" do
+    test "returns noreply by default" do
+      assert Consumer.handle_cast(:anything, %{}) == {:noreply, %{}}
+    end
+  end
+
+  describe "handle_info/2" do
+    test "returns noreply by default" do
+      assert Consumer.handle_info(:anything, %{}) == {:noreply, %{}}
+    end
+  end
+end


### PR DESCRIPTION
Switching to `use Pulsar.Consumer.Callback` ensures that default implementations for optional callbacks are injected. Prior to this fix the optional callbacks such as `terminate/2` were not implemented nor inherited.

This is causing the following error:

```json
{
  "message": "Error in callback terminate function: %UndefinedFunctionError{module: OffBroadway.Pulsar.Consumer, function: :terminate, arity: 2, reason: nil, message: nil}",
  "time": "2026-05-08T05:40:42.033Z",
  "metadata": {
    "line": 761,
    "file": "lib/pulsar/consumer.ex",
    "domain": [
      "elixir"
    ],
    "application": "pulsar",
    "mfa": "Elixir.Pulsar.Consumer.terminate/2"
  },
  "severity": "warning"
}
```