### PR TITLE
ci: bump version in readme on new release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add `:off_broadway_pulsar` to your dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:off_broadway_pulsar, "~> 1.3.11"}
+    {:off_broadway_pulsar, "~> 1.3.11"} <!-- x-release-please-version -->
   ]
 end
 ```


### PR DESCRIPTION
### Description

Allow `release-please` to bump `off_broadway_pulsar`'s release in the `README.md` file on every new release.