### PR TITLE
deps: bump erlang and elixir versions to 29 and 1.20

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,6 +1,6 @@
 [tools]
-elixir = "1.18.4"
-erlang = "28.1"
+elixir = "1.20"
+erlang = "29.0"
 protoc = "25.1"
 
 [tasks.deps]

--- a/mix.exs
+++ b/mix.exs
@@ -11,12 +11,6 @@ defmodule OffBroadwayPulsar.MixProject do
       deps: deps(),
       consolidate_protocols: Mix.env() != :test,
       test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: [
-        coveralls: :test,
-        "coveralls.detail": :test,
-        "coveralls.post": :test,
-        "coveralls.html": :test
-      ],
       dialyzer: [
         plt_add_apps: [:pulsar]
       ],
@@ -26,6 +20,17 @@ defmodule OffBroadwayPulsar.MixProject do
       docs: [
         main: "OffBroadway.Pulsar.Producer",
         extras: ["README.md"]
+      ]
+    ]
+  end
+
+  def cli do
+    [
+      preferred_envs: [
+        coveralls: :test,
+        "coveralls.detail": :test,
+        "coveralls.post": :test,
+        "coveralls.html": :test
       ]
     ]
   end


### PR DESCRIPTION
### Description

Bump Erlang and Elixir versions to `29` and `1.20` respectively.