### PR TITLE
fix: tie consumer lifetime to the stage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ children = [
 ]
 ```
 
+The consumers themselves belong to the producer stage that started them. They are linked to
+it, so they go down with the pipeline rather than outliving it holding the subscription, and
+the stage goes down with them rather than running on with nothing to consume from.
+
 Then, assuming Pulsar is running on `localhost:6650`:
 
 ```elixir

--- a/README.md
+++ b/README.md
@@ -96,8 +96,8 @@ producer: [
 
 Broadway and pulsar-elixir have different lifecycle boundaries. The `Pulsar.Client` owns
 shared connection infrastructure; each Broadway producer stage owns the consumers that feed
-it. A consumer root therefore uses the client's Registry and brokers without being a child of
-the client's consumer `DynamicSupervisor`.
+it. A consumer root therefore uses the client's infrastructure without being a child of the
+client's consumer `DynamicSupervisor`.
 
 ```mermaid
 flowchart TD
@@ -129,7 +129,7 @@ flowchart TD
 | A consumer root exits | Its link or monitor stops the stage; Broadway recreates it |
 | A retryable worker failure occurs | Pulsar's topology supervision restarts the worker |
 | A terminal subscription error stops a group | The stage's health check detects it and restarts |
-| The consumer Registry is replaced | Its monitor stops the stage so new roots register with the replacement |
+| The consumer Registry is replaced | Existing roots keep running by pid, but their former names no longer resolve |
 | A broker connection fails | The affected workers restart and reconnect through the client |
 
 Because the roots belong to their producer stages, `Pulsar.Client.consumers/1` does not list

--- a/README.md
+++ b/README.md
@@ -31,10 +31,6 @@ children = [
 ]
 ```
 
-The consumers themselves belong to the producer stage that started them. They are linked to
-it, so they go down with the pipeline rather than outliving it holding the subscription, and
-the stage goes down with them rather than running on with nothing to consume from.
-
 Then, assuming Pulsar is running on `localhost:6650`:
 
 ```elixir
@@ -95,6 +91,49 @@ producer: [
   concurrency: 1
 ]
 ```
+
+## Architecture and failure propagation
+
+Broadway and pulsar-elixir have different lifecycle boundaries. The `Pulsar.Client` owns
+shared connection infrastructure; each Broadway producer stage owns the consumers that feed
+it. A consumer root therefore uses the client's Registry and brokers without being a child of
+the client's consumer `DynamicSupervisor`.
+
+```mermaid
+flowchart TD
+  APP[Application supervisor]
+  CLIENT[Pulsar.Client]
+  PIPELINE[Broadway pipeline]
+  STAGE[Producer stage]
+  ROOT[Consumer root<br/>one per topic]
+  GROUP[Topic or partition group]
+  WORKER[Consumer worker]
+  REGISTRY[Consumer Registry]
+  BROKER[Broker processes]
+
+  APP --> CLIENT
+  APP --> PIPELINE
+  PIPELINE --> STAGE
+  STAGE <-->|linked ownership| ROOT
+  ROOT -->|supervises| GROUP
+  GROUP -->|supervises| WORKER
+  CLIENT --> REGISTRY
+  CLIENT --> BROKER
+  ROOT -. registers with .-> REGISTRY
+  WORKER -. communicates with .-> BROKER
+```
+
+| Event | Result |
+| --- | --- |
+| The producer stage exits | Its linked consumer roots stop |
+| A consumer root exits | Its link or monitor stops the stage; Broadway recreates it |
+| A retryable worker failure occurs | Pulsar's topology supervision restarts the worker |
+| A terminal subscription error stops a group | The stage's health check detects it and restarts |
+| The consumer Registry is replaced | Its monitor stops the stage so new roots register with the replacement |
+| A broker connection fails | The affected workers restart and reconnect through the client |
+
+Because the roots belong to their producer stages, `Pulsar.Client.consumers/1` does not list
+them. Stop the Broadway pipeline, rather than an individual root, to stop them permanently.
 
 ## Message metadata
 

--- a/lib/off_broadway/pulsar/producer.ex
+++ b/lib/off_broadway/pulsar/producer.ex
@@ -10,9 +10,8 @@ defmodule OffBroadway.Pulsar.Producer do
   The connection belongs to your application: supervise a `Pulsar.Client` and this
   producer attaches its consumers to it.
 
-  The consumers are owned by the producer stage rather than by the client: they are
-  started with `Pulsar.Consumer.start_link/1`, so the stage and the consumers feeding
-  it share a fate. See "Consumer ownership" in `start_link/1`.
+  Each producer stage owns the consumers it starts. See "Consumer ownership" in
+  `start_link/1`.
 
   See `start_link/1` for detailed configuration options.
   """
@@ -52,14 +51,10 @@ defmodule OffBroadway.Pulsar.Producer do
   @default_flow_threshold 50
   @default_flow_refill 50
 
-  # How often the stage checks on the consumers it owns. Neither failure it looks for sends
-  # this stage anything: a worker that fails terminally before its callback runs was never
-  # reported here, and a lost registration is silent by construction. See check_consumers/1.
+  # Terminal subscription errors can stop a group without stopping its root.
   @health_check_interval_ms 5_000
 
-  # A stage restarting because its client's consumer branch was replaced can arrive before
-  # the replacement registry does. Waiting briefly rebuilds against it instead of raising
-  # into Broadway's restart budget.
+  # A stage can restart before the client's replacement Registry is ready.
   @registry_wait_ms 2_000
   @registry_poll_ms 100
 
@@ -124,29 +119,20 @@ defmodule OffBroadway.Pulsar.Producer do
 
   ## Consumer ownership
 
-  Consumers are started with `Pulsar.Consumer.start_link/1`, which links each consumer root
-  to the producer stage that started it. The link carries ownership in both directions:
+  Each producer stage starts one linked consumer root per topic. Pulsar supervises the
+  partition groups and workers below each root; Broadway supervises the stage. If the stage
+  or a root exits, Broadway restarts the stage and recreates all of its roots. Retryable
+  worker failures remain local to the Pulsar topology.
 
-  - The stage exits and its consumer roots exit with it, unsubscribing rather than
-    lingering as orphans that hold the subscription and deliver to a dead pid.
-  - A consumer root exits and the stage exits with it. Broadway restarts the stage, and
-    `init/1` recreates the consumers.
+  Consumer roots use the client's brokers and Registry, but are not children of its consumer
+  `DynamicSupervisor`. Consequently, `Pulsar.Client.consumers/1` does not list them. They can
+  still be resolved by name, although stopping one with `Pulsar.Consumer.stop/2` causes its
+  owning stage to recreate it. Stop the Broadway pipeline to stop its consumers permanently.
 
-  Three consequences are worth knowing:
-
-  - The consumers are supervised by Broadway's producer supervisor, not by the client's
-    consumer `DynamicSupervisor`, so `Pulsar.Client.consumers/1` does not list them. They
-    are still registered in the client's consumer registry, so `Pulsar.Consumer.stop/2`
-    and anything else resolving a consumer by name still finds them. Stopping one that way
-    is undone: the stage notices it has no consumer and is restarted with a new one.
-  - Failure that a consumer cannot recover from takes the pipeline down instead of leaving
-    it running and silent. A consumer worker that stops on a terminal subscribe error
-    (`:ConsumerBusy`, `:AuthorizationError`, `:TopicNotFound` and friends) stops the stage,
-    as does the client's consumer branch being replaced underneath it. Ordinary worker
-    crashes are left to the client's own supervision and do not disturb the stage.
-  - Because the client's consumer registry holds the consumer names, the stage stops when it
-    finds its own registration gone, so that `init/1` can re-register against the registry
-    that replaced it.
+  A terminal subscription error can leave a root alive with a stopped group. The stage
+  detects that state and restarts instead of remaining healthy with nothing to consume.
+  Replacing the client's consumer Registry likewise restarts the stage so its roots register
+  with the replacement.
 
   ## Message Metadata
 
@@ -261,8 +247,6 @@ defmodule OffBroadway.Pulsar.Producer do
 
     ensure_client_running!(client)
 
-    # Validated before any consumer is started, so a misconfigured stage never subscribes
-    # only to raise on the option after it.
     flow_initial =
       opts
       |> Keyword.get(:flow_initial, @default_flow_initial)
@@ -283,9 +267,8 @@ defmodule OffBroadway.Pulsar.Producer do
             "flow_threshold (#{flow_threshold}) must be less than flow_initial (#{flow_initial})"
     end
 
-    # The consumer names are registered here, so a stage that got ahead of its client's
-    # restart waits for the registry rather than raising into Broadway's restart budget.
-    await_consumer_registry!(client)
+    registry = await_consumer_registry!(client)
+    registry_monitor = Process.monitor(registry)
 
     # Each worker grants its own initial window on subscribe, so restarts and
     # late-discovered partitions come back with permits rather than waiting to be given
@@ -300,8 +283,7 @@ defmodule OffBroadway.Pulsar.Producer do
         flow_policy: {Callback, :report_permits, [self()]}
       )
 
-    # The unique name keeps multi-topic and producer concurrency > 1 apart. Each root is
-    # linked to this producer, which owns it; see "Consumer ownership".
+    # One linked root per topic; unique names also separate concurrent producer stages.
     consumer_roots =
       Map.new(topics, fn topic ->
         unique_name = "#{topic}-#{subscription}-#{System.unique_integer([:positive])}"
@@ -315,7 +297,8 @@ defmodule OffBroadway.Pulsar.Producer do
             init_args: [self(), active_state_callback]
           )
 
-        {start_consumer!(topic_opts), {topic, unique_name}}
+        root = start_consumer!(topic_opts)
+        {root, {topic, Process.monitor(root)}}
       end)
 
     state = %{
@@ -323,10 +306,10 @@ defmodule OffBroadway.Pulsar.Producer do
       # Permits belong to a worker instance, so the worker is the key; the topic only
       # rides along for logging.
       consumers: %{},
-      # root pid => {topic, registered name}, for the consumers this stage owns. Linked, so
-      # a root that exits takes the stage with it before any monitor would report it.
+      # root pid => {topic, monitor_ref}
       consumer_roots: consumer_roots,
       client: client,
+      registry_monitor: {registry, registry_monitor},
       demand: 0,
       # An ordered mix of {:message, %Pulsar.Message{}, consumer_pid, context} and
       # {:permits, consumer_pid, consumed} markers. See take_dispatchable/3.
@@ -369,47 +352,34 @@ defmodule OffBroadway.Pulsar.Producer do
     dispatch_messages(%{state | buffer: state.buffer ++ [{:permits, consumer_pid, consumed}]})
   end
 
-  # A worker stopping with `{:shutdown, {code, message}}` hit an error the client refuses to
-  # retry: a subscription already taken, credentials that stay rejected, a topic that is not
-  # there. Its group is gone with it, so this stage has no consumer left for that topic.
-  def handle_info({:DOWN, _ref, :process, consumer_pid, {:shutdown, {code, _message} = reason}}, state)
-      when is_atom(code) do
-    case state.consumers do
-      %{^consumer_pid => {topic, _outstanding}} ->
-        Logger.error("Consumer for #{topic} stopped on a terminal error: #{inspect(reason)}")
+  def handle_info({:DOWN, monitor_ref, :process, registry, reason}, %{registry_monitor: {registry, monitor_ref}} = state) do
+    Logger.error("Consumer Registry for client #{inspect(state.client)} exited: #{inspect(reason)}; stopping")
 
-        {:stop, {:shutdown, {:consumer_terminal_error, topic, reason}}, state}
+    {:stop, {:shutdown, {:consumer_registry_down, state.client}}, state}
+  end
 
-      _no_such_consumer ->
-        forget_consumer(consumer_pid, state)
+  def handle_info({:DOWN, monitor_ref, :process, pid, reason}, state) do
+    case state.consumer_roots do
+      %{^pid => {topic, ^monitor_ref}} ->
+        Logger.error("Consumer root for #{topic} exited: #{inspect(reason)}; stopping")
+
+        {:stop, {:shutdown, {:consumer_gone, topic}}, state}
+
+      _worker_or_unknown ->
+        forget_consumer(pid, state)
     end
   end
 
-  def handle_info({:DOWN, _ref, :process, consumer_pid, _reason}, state) do
-    forget_consumer(consumer_pid, state)
-  end
-
   def handle_info(:check_consumers, state) do
-    schedule_health_check()
-
     case check_consumers(state) do
       :ok ->
+        schedule_health_check()
         {:noreply, [], state}
-
-      {:gone, topic} ->
-        Logger.error("Consumer for #{topic} is gone; stopping")
-
-        {:stop, {:shutdown, {:consumer_gone, topic}}, state}
 
       {:stopped, topic} ->
         Logger.error("Consumer for #{topic} has a stopped group and no worker left; stopping")
 
         {:stop, {:shutdown, {:consumer_stopped, topic}}, state}
-
-      {:unregistered, topic} ->
-        Logger.error("Consumer for #{topic} is no longer registered with client #{inspect(state.client)}; stopping")
-
-        {:stop, {:shutdown, {:consumer_unregistered, topic}}, state}
     end
   end
 
@@ -526,35 +496,11 @@ defmodule OffBroadway.Pulsar.Producer do
 
   defp schedule_health_check, do: Process.send_after(self(), :check_consumers, @health_check_interval_ms)
 
-  # Three failures the link does not report.
-  #
-  # A root that is gone. The link only carries an abnormal exit, and a root stopped through
-  # `Pulsar.Consumer.stop/2` exits `:normal`, which this stage ignores — so without this the
-  # stage would run on believing it has a consumer that no longer exists.
-  #
-  # The other two leave the root itself up, so no exit signal is sent at all.
-  #
-  # A group with no pid stopped and was not restarted, which the client only does for a
-  # failure retrying cannot fix. The worker that hit it is invisible to this stage when it
-  # failed before its callback ran — a terminal subscribe error always does.
-  #
-  # A name that no longer resolves to the root means the client's consumer registry was
-  # replaced under it: the registry links its registrants, but a root is a supervisor and
-  # ignores an exit from a link that is neither its parent nor its child, so it survives
-  # unregistered. Registration is not re-created, so the stage restarts to re-create it.
+  # Terminal subscription errors can stop a group without stopping its root.
   defp check_consumers(state) do
-    Enum.reduce_while(state.consumer_roots, :ok, fn {root, {topic, name}}, :ok ->
-      cond do
-        not Process.alive?(root) -> {:halt, {:gone, topic}}
-        stopped_group?(root) -> {:halt, {:stopped, topic}}
-        not registered?(name, root, state.client) -> {:halt, {:unregistered, topic}}
-        true -> {:cont, :ok}
-      end
+    Enum.reduce_while(state.consumer_roots, :ok, fn {root, {topic, _monitor_ref}}, :ok ->
+      if stopped_group?(root), do: {:halt, {:stopped, topic}}, else: {:cont, :ok}
     end)
-  end
-
-  defp registered?(name, root, client) do
-    Pulsar.Client.lookup(:consumers, name, client) == {:ok, root}
   end
 
   defp stopped_group?(root) do
@@ -566,13 +512,10 @@ defmodule OffBroadway.Pulsar.Producer do
       _child -> false
     end)
   catch
-    # A root busy starting children answers on the next round, and one that exited between
-    # the liveness check above and this call is caught by that check on the next round.
+    # Root exits are reported by its monitor.
     :exit, _reason -> false
   end
 
-  # Linked, so the roots go down with this stage rather than outliving it holding the
-  # subscription, and this stage goes down with a root rather than idling without consumers.
   defp start_consumer!(opts) do
     case Pulsar.Consumer.start_link(opts) do
       {:ok, consumer} ->
@@ -599,13 +542,14 @@ defmodule OffBroadway.Pulsar.Producer do
   defp await_consumer_registry!(client) do
     registry = Pulsar.Client.registry(:consumers, client)
 
-    if is_nil(await_registry(registry, @registry_wait_ms)) do
-      raise ArgumentError,
-            "Pulsar client #{inspect(client)} is running but its consumer registry " <>
-              "#{inspect(registry)} is not; the client is still starting up or shutting down"
-    end
+    case await_registry(registry, @registry_wait_ms) do
+      nil ->
+        raise "Pulsar client #{inspect(client)} is running but its consumer Registry " <>
+                "#{inspect(registry)} is not; the client is still starting up or shutting down"
 
-    :ok
+      pid ->
+        pid
+    end
   end
 
   defp await_registry(registry, remaining_ms) do

--- a/lib/off_broadway/pulsar/producer.ex
+++ b/lib/off_broadway/pulsar/producer.ex
@@ -137,7 +137,8 @@ defmodule OffBroadway.Pulsar.Producer do
   - The consumers are supervised by Broadway's producer supervisor, not by the client's
     consumer `DynamicSupervisor`, so `Pulsar.Client.consumers/1` does not list them. They
     are still registered in the client's consumer registry, so `Pulsar.Consumer.stop/2`
-    and anything else resolving a consumer by name still finds them.
+    and anything else resolving a consumer by name still finds them. Stopping one that way
+    is undone: the stage notices it has no consumer and is restarted with a new one.
   - Failure that a consumer cannot recover from takes the pipeline down instead of leaving
     it running and silent. A consumer worker that stops on a terminal subscribe error
     (`:ConsumerBusy`, `:AuthorizationError`, `:TopicNotFound` and friends) stops the stage,
@@ -395,6 +396,11 @@ defmodule OffBroadway.Pulsar.Producer do
       :ok ->
         {:noreply, [], state}
 
+      {:gone, topic} ->
+        Logger.error("Consumer for #{topic} is gone; stopping")
+
+        {:stop, {:shutdown, {:consumer_gone, topic}}, state}
+
       {:stopped, topic} ->
         Logger.error("Consumer for #{topic} has a stopped group and no worker left; stopping")
 
@@ -520,7 +526,13 @@ defmodule OffBroadway.Pulsar.Producer do
 
   defp schedule_health_check, do: Process.send_after(self(), :check_consumers, @health_check_interval_ms)
 
-  # Two failures a linked root does not report, because the root stays up through both.
+  # Three failures the link does not report.
+  #
+  # A root that is gone. The link only carries an abnormal exit, and a root stopped through
+  # `Pulsar.Consumer.stop/2` exits `:normal`, which this stage ignores — so without this the
+  # stage would run on believing it has a consumer that no longer exists.
+  #
+  # The other two leave the root itself up, so no exit signal is sent at all.
   #
   # A group with no pid stopped and was not restarted, which the client only does for a
   # failure retrying cannot fix. The worker that hit it is invisible to this stage when it
@@ -533,9 +545,7 @@ defmodule OffBroadway.Pulsar.Producer do
   defp check_consumers(state) do
     Enum.reduce_while(state.consumer_roots, :ok, fn {root, {topic, name}}, :ok ->
       cond do
-        # A root that exited has an exit signal on its way here already; the link answers
-        # for it, and this pass has nothing useful to say about it.
-        not Process.alive?(root) -> {:cont, :ok}
+        not Process.alive?(root) -> {:halt, {:gone, topic}}
         stopped_group?(root) -> {:halt, {:stopped, topic}}
         not registered?(name, root, state.client) -> {:halt, {:unregistered, topic}}
         true -> {:cont, :ok}
@@ -556,8 +566,8 @@ defmodule OffBroadway.Pulsar.Producer do
       _child -> false
     end)
   catch
-    # A root busy starting children answers on the next round, and one that is gone has
-    # already taken this stage with it through the link.
+    # A root busy starting children answers on the next round, and one that exited between
+    # the liveness check above and this call is caught by that check on the next round.
     :exit, _reason -> false
   end
 

--- a/lib/off_broadway/pulsar/producer.ex
+++ b/lib/off_broadway/pulsar/producer.ex
@@ -54,10 +54,6 @@ defmodule OffBroadway.Pulsar.Producer do
   # Terminal subscription errors can stop a group without stopping its root.
   @health_check_interval_ms 5_000
 
-  # A stage can restart before the client's replacement Registry is ready.
-  @registry_wait_ms 2_000
-  @registry_poll_ms 100
-
   @doc """
   Starts an `OffBroadway.Pulsar` producer process linked to the current
   process.
@@ -120,19 +116,17 @@ defmodule OffBroadway.Pulsar.Producer do
   ## Consumer ownership
 
   Each producer stage starts one linked consumer root per topic. Pulsar supervises the
-  partition groups and workers below each root; Broadway supervises the stage. If the stage
-  or a root exits, Broadway restarts the stage and recreates all of its roots. Retryable
-  worker failures remain local to the Pulsar topology.
+  partition groups and workers below each root; Broadway supervises the stage. A root exit
+  makes Broadway restart the stage and recreate all of its roots, while stopping the stage
+  stops its linked roots. Retryable worker failures remain local to the Pulsar topology.
 
-  Consumer roots use the client's brokers and Registry, but are not children of its consumer
-  `DynamicSupervisor`. Consequently, `Pulsar.Client.consumers/1` does not list them. They can
-  still be resolved by name, although stopping one with `Pulsar.Consumer.stop/2` causes its
-  owning stage to recreate it. Stop the Broadway pipeline to stop its consumers permanently.
+  Consumer roots use the client's broker infrastructure but are not children of its consumer
+  `DynamicSupervisor`. Consequently, `Pulsar.Client.consumers/1` does not list them. The stage
+  owns them by pid, so replacing the client's consumer Registry does not affect them, although
+  their former names no longer resolve. Stop the Broadway pipeline to stop them permanently.
 
   A terminal subscription error can leave a root alive with a stopped group. The stage
   detects that state and restarts instead of remaining healthy with nothing to consume.
-  Replacing the client's consumer Registry likewise restarts the stage so its roots register
-  with the replacement.
 
   ## Message Metadata
 
@@ -267,9 +261,6 @@ defmodule OffBroadway.Pulsar.Producer do
             "flow_threshold (#{flow_threshold}) must be less than flow_initial (#{flow_initial})"
     end
 
-    registry = await_consumer_registry!(client)
-    registry_monitor = Process.monitor(registry)
-
     # Each worker grants its own initial window on subscribe, so restarts and
     # late-discovered partitions come back with permits rather than waiting to be given
     # any. Refills are this producer's, driven by what Broadway takes.
@@ -308,8 +299,6 @@ defmodule OffBroadway.Pulsar.Producer do
       consumers: %{},
       # root pid => {topic, monitor_ref}
       consumer_roots: consumer_roots,
-      client: client,
-      registry_monitor: {registry, registry_monitor},
       demand: 0,
       # An ordered mix of {:message, %Pulsar.Message{}, consumer_pid, context} and
       # {:permits, consumer_pid, consumed} markers. See take_dispatchable/3.
@@ -350,12 +339,6 @@ defmodule OffBroadway.Pulsar.Producer do
 
   def handle_info({:permits_consumed, consumer_pid, consumed}, state) do
     dispatch_messages(%{state | buffer: state.buffer ++ [{:permits, consumer_pid, consumed}]})
-  end
-
-  def handle_info({:DOWN, monitor_ref, :process, registry, reason}, %{registry_monitor: {registry, monitor_ref}} = state) do
-    Logger.error("Consumer Registry for client #{inspect(state.client)} exited: #{inspect(reason)}; stopping")
-
-    {:stop, {:shutdown, {:consumer_registry_down, state.client}}, state}
   end
 
   def handle_info({:DOWN, monitor_ref, :process, pid, reason}, state) do
@@ -536,30 +519,6 @@ defmodule OffBroadway.Pulsar.Producer do
             MyApp.PulsarPipeline
           ]
       """
-    end
-  end
-
-  defp await_consumer_registry!(client) do
-    registry = Pulsar.Client.registry(:consumers, client)
-
-    case await_registry(registry, @registry_wait_ms) do
-      nil ->
-        raise "Pulsar client #{inspect(client)} is running but its consumer Registry " <>
-                "#{inspect(registry)} is not; the client is still starting up or shutting down"
-
-      pid ->
-        pid
-    end
-  end
-
-  defp await_registry(registry, remaining_ms) do
-    case Process.whereis(registry) do
-      nil when remaining_ms > 0 ->
-        Process.sleep(@registry_poll_ms)
-        await_registry(registry, remaining_ms - @registry_poll_ms)
-
-      found_or_nil ->
-        found_or_nil
     end
   end
 

--- a/lib/off_broadway/pulsar/producer.ex
+++ b/lib/off_broadway/pulsar/producer.ex
@@ -10,6 +10,10 @@ defmodule OffBroadway.Pulsar.Producer do
   The connection belongs to your application: supervise a `Pulsar.Client` and this
   producer attaches its consumers to it.
 
+  The consumers are owned by the producer stage rather than by the client: they are
+  started with `Pulsar.Consumer.start_link/1`, so the stage and the consumers feeding
+  it share a fate. See "Consumer ownership" in `start_link/1`.
+
   See `start_link/1` for detailed configuration options.
   """
 
@@ -48,6 +52,17 @@ defmodule OffBroadway.Pulsar.Producer do
   @default_flow_threshold 50
   @default_flow_refill 50
 
+  # How often the stage checks on the consumers it owns. Neither failure it looks for sends
+  # this stage anything: a worker that fails terminally before its callback runs was never
+  # reported here, and a lost registration is silent by construction. See check_consumers/1.
+  @health_check_interval_ms 5_000
+
+  # A stage restarting because its client's consumer branch was replaced can arrive before
+  # the replacement registry does. Waiting briefly rebuilds against it instead of raising
+  # into Broadway's restart budget.
+  @registry_wait_ms 2_000
+  @registry_poll_ms 100
+
   @doc """
   Starts an `OffBroadway.Pulsar` producer process linked to the current
   process.
@@ -63,7 +78,7 @@ defmodule OffBroadway.Pulsar.Producer do
   - `:subscription` - The subscription name (required)
   - `:active_state_callback` - An optional `{module, function, extra_args}` tuple that receives
     active/passive state changes for Failover consumers. See "Failover Active State" below.
-  - `:consumer_opts` - Consumer-specific options passed to `Pulsar.Consumer.start/1` (optional).
+  - `:consumer_opts` - Consumer-specific options passed to `Pulsar.Consumer.start_link/1` (optional).
     Applied to all topics when using `:topics`.
     - `:subscription_type` - Subscription type (`:exclusive`, `:failover`, `:shared`, `:key_shared`, default: `:shared`)
     - `:initial_position` - Initial position (`:latest` or `:earliest`, default: `:latest`)
@@ -106,6 +121,31 @@ defmodule OffBroadway.Pulsar.Producer do
   Each consumer keeps its own window — one per topic, and one per partition of a
   partitioned topic. With `producer: [concurrency: N]`, each producer has its own
   consumers, and so its own windows.
+
+  ## Consumer ownership
+
+  Consumers are started with `Pulsar.Consumer.start_link/1`, which links each consumer root
+  to the producer stage that started it. The link carries ownership in both directions:
+
+  - The stage exits and its consumer roots exit with it, unsubscribing rather than
+    lingering as orphans that hold the subscription and deliver to a dead pid.
+  - A consumer root exits and the stage exits with it. Broadway restarts the stage, and
+    `init/1` recreates the consumers.
+
+  Three consequences are worth knowing:
+
+  - The consumers are supervised by Broadway's producer supervisor, not by the client's
+    consumer `DynamicSupervisor`, so `Pulsar.Client.consumers/1` does not list them. They
+    are still registered in the client's consumer registry, so `Pulsar.Consumer.stop/2`
+    and anything else resolving a consumer by name still finds them.
+  - Failure that a consumer cannot recover from takes the pipeline down instead of leaving
+    it running and silent. A consumer worker that stops on a terminal subscribe error
+    (`:ConsumerBusy`, `:AuthorizationError`, `:TopicNotFound` and friends) stops the stage,
+    as does the client's consumer branch being replaced underneath it. Ordinary worker
+    crashes are left to the client's own supervision and do not disturb the stage.
+  - Because the client's consumer registry holds the consumer names, the stage stops when it
+    finds its own registration gone, so that `init/1` can re-register against the registry
+    that replaced it.
 
   ## Message Metadata
 
@@ -220,8 +260,8 @@ defmodule OffBroadway.Pulsar.Producer do
 
     ensure_client_running!(client)
 
-    # Validate flow options before starting consumers; failed init retries would
-    # otherwise leak client-supervised consumers.
+    # Validated before any consumer is started, so a misconfigured stage never subscribes
+    # only to raise on the option after it.
     flow_initial =
       opts
       |> Keyword.get(:flow_initial, @default_flow_initial)
@@ -242,6 +282,10 @@ defmodule OffBroadway.Pulsar.Producer do
             "flow_threshold (#{flow_threshold}) must be less than flow_initial (#{flow_initial})"
     end
 
+    # The consumer names are registered here, so a stage that got ahead of its client's
+    # restart waits for the registry rather than raising into Broadway's restart budget.
+    await_consumer_registry!(client)
+
     # Each worker grants its own initial window on subscribe, so restarts and
     # late-discovered partitions come back with permits rather than waiting to be given
     # any. Refills are this producer's, driven by what Broadway takes.
@@ -255,28 +299,33 @@ defmodule OffBroadway.Pulsar.Producer do
         flow_policy: {Callback, :report_permits, [self()]}
       )
 
-    # The unique name keeps multi-topic and producer concurrency > 1 apart. Consumers run
-    # under the client's supervisor, not under this producer.
-    Enum.each(topics, fn topic ->
-      unique_name = "#{topic}-#{subscription}-#{System.unique_integer([:positive])}"
+    # The unique name keeps multi-topic and producer concurrency > 1 apart. Each root is
+    # linked to this producer, which owns it; see "Consumer ownership".
+    consumer_roots =
+      Map.new(topics, fn topic ->
+        unique_name = "#{topic}-#{subscription}-#{System.unique_integer([:positive])}"
 
-      topic_opts =
-        Keyword.merge(consumer_opts_base,
-          topic: topic,
-          subscription_name: subscription,
-          callback_module: Callback,
-          name: unique_name,
-          init_args: [self(), active_state_callback]
-        )
+        topic_opts =
+          Keyword.merge(consumer_opts_base,
+            topic: topic,
+            subscription_name: subscription,
+            callback_module: Callback,
+            name: unique_name,
+            init_args: [self(), active_state_callback]
+          )
 
-      start_consumer!(topic_opts)
-    end)
+        {start_consumer!(topic_opts), {topic, unique_name}}
+      end)
 
     state = %{
       # consumer_pid => {topic, outstanding_permits}, populated via :consumer_ready.
       # Permits belong to a worker instance, so the worker is the key; the topic only
       # rides along for logging.
       consumers: %{},
+      # root pid => {topic, registered name}, for the consumers this stage owns. Linked, so
+      # a root that exits takes the stage with it before any monitor would report it.
+      consumer_roots: consumer_roots,
+      client: client,
       demand: 0,
       # An ordered mix of {:message, %Pulsar.Message{}, consumer_pid, context} and
       # {:permits, consumer_pid, consumed} markers. See take_dispatchable/3.
@@ -285,6 +334,8 @@ defmodule OffBroadway.Pulsar.Producer do
       flow_threshold: flow_threshold,
       flow_refill: flow_refill
     }
+
+    schedule_health_check()
 
     {:producer, state}
   end
@@ -317,7 +368,46 @@ defmodule OffBroadway.Pulsar.Producer do
     dispatch_messages(%{state | buffer: state.buffer ++ [{:permits, consumer_pid, consumed}]})
   end
 
+  # A worker stopping with `{:shutdown, {code, message}}` hit an error the client refuses to
+  # retry: a subscription already taken, credentials that stay rejected, a topic that is not
+  # there. Its group is gone with it, so this stage has no consumer left for that topic.
+  def handle_info({:DOWN, _ref, :process, consumer_pid, {:shutdown, {code, _message} = reason}}, state)
+      when is_atom(code) do
+    case state.consumers do
+      %{^consumer_pid => {topic, _outstanding}} ->
+        Logger.error("Consumer for #{topic} stopped on a terminal error: #{inspect(reason)}")
+
+        {:stop, {:shutdown, {:consumer_terminal_error, topic, reason}}, state}
+
+      _no_such_consumer ->
+        forget_consumer(consumer_pid, state)
+    end
+  end
+
   def handle_info({:DOWN, _ref, :process, consumer_pid, _reason}, state) do
+    forget_consumer(consumer_pid, state)
+  end
+
+  def handle_info(:check_consumers, state) do
+    schedule_health_check()
+
+    case check_consumers(state) do
+      :ok ->
+        {:noreply, [], state}
+
+      {:stopped, topic} ->
+        Logger.error("Consumer for #{topic} has a stopped group and no worker left; stopping")
+
+        {:stop, {:shutdown, {:consumer_stopped, topic}}, state}
+
+      {:unregistered, topic} ->
+        Logger.error("Consumer for #{topic} is no longer registered with client #{inspect(state.client)}; stopping")
+
+        {:stop, {:shutdown, {:consumer_unregistered, topic}}, state}
+    end
+  end
+
+  defp forget_consumer(consumer_pid, state) do
     # Entries from a dead worker can no longer be acknowledged; discard them and
     # their permit markers.
     buffer =
@@ -428,12 +518,54 @@ defmodule OffBroadway.Pulsar.Producer do
     end
   end
 
-  defp start_consumer!(opts) do
-    case Pulsar.Consumer.start(opts) do
-      {:ok, consumer} ->
-        consumer
+  defp schedule_health_check, do: Process.send_after(self(), :check_consumers, @health_check_interval_ms)
 
-      {:ok, consumer, _info} ->
+  # Two failures a linked root does not report, because the root stays up through both.
+  #
+  # A group with no pid stopped and was not restarted, which the client only does for a
+  # failure retrying cannot fix. The worker that hit it is invisible to this stage when it
+  # failed before its callback ran — a terminal subscribe error always does.
+  #
+  # A name that no longer resolves to the root means the client's consumer registry was
+  # replaced under it: the registry links its registrants, but a root is a supervisor and
+  # ignores an exit from a link that is neither its parent nor its child, so it survives
+  # unregistered. Registration is not re-created, so the stage restarts to re-create it.
+  defp check_consumers(state) do
+    Enum.reduce_while(state.consumer_roots, :ok, fn {root, {topic, name}}, :ok ->
+      cond do
+        # A root that exited has an exit signal on its way here already; the link answers
+        # for it, and this pass has nothing useful to say about it.
+        not Process.alive?(root) -> {:cont, :ok}
+        stopped_group?(root) -> {:halt, {:stopped, topic}}
+        not registered?(name, root, state.client) -> {:halt, {:unregistered, topic}}
+        true -> {:cont, :ok}
+      end
+    end)
+  end
+
+  defp registered?(name, root, client) do
+    Pulsar.Client.lookup(:consumers, name, client) == {:ok, root}
+  end
+
+  defp stopped_group?(root) do
+    root
+    |> Supervisor.which_children()
+    |> Enum.any?(fn
+      {{:topic, :non_partitioned}, :undefined, _type, _modules} -> true
+      {{:partition, _index}, :undefined, _type, _modules} -> true
+      _child -> false
+    end)
+  catch
+    # A root busy starting children answers on the next round, and one that is gone has
+    # already taken this stage with it through the link.
+    :exit, _reason -> false
+  end
+
+  # Linked, so the roots go down with this stage rather than outliving it holding the
+  # subscription, and this stage goes down with a root rather than idling without consumers.
+  defp start_consumer!(opts) do
+    case Pulsar.Consumer.start_link(opts) do
+      {:ok, consumer} ->
         consumer
 
       other ->
@@ -451,6 +583,29 @@ defmodule OffBroadway.Pulsar.Producer do
             MyApp.PulsarPipeline
           ]
       """
+    end
+  end
+
+  defp await_consumer_registry!(client) do
+    registry = Pulsar.Client.registry(:consumers, client)
+
+    if is_nil(await_registry(registry, @registry_wait_ms)) do
+      raise ArgumentError,
+            "Pulsar client #{inspect(client)} is running but its consumer registry " <>
+              "#{inspect(registry)} is not; the client is still starting up or shutting down"
+    end
+
+    :ok
+  end
+
+  defp await_registry(registry, remaining_ms) do
+    case Process.whereis(registry) do
+      nil when remaining_ms > 0 ->
+        Process.sleep(@registry_poll_ms)
+        await_registry(registry, remaining_ms - @registry_poll_ms)
+
+      found_or_nil ->
+        found_or_nil
     end
   end
 

--- a/lib/off_broadway/pulsar/producer.ex
+++ b/lib/off_broadway/pulsar/producer.ex
@@ -366,6 +366,13 @@ defmodule OffBroadway.Pulsar.Producer do
     end
   end
 
+  @impl GenStage
+  def terminate(_reason, state) do
+    Enum.each(state.consumer_roots, fn {root, _metadata} ->
+      Pulsar.Consumer.stop(root)
+    end)
+  end
+
   defp forget_consumer(consumer_pid, state) do
     # Entries from a dead worker can no longer be acknowledged; discard them and
     # their permit markers.

--- a/test/integration/producer_test.exs
+++ b/test/integration/producer_test.exs
@@ -11,6 +11,8 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
   @topic_a "persistent://public/default/broadway-multi-topic-a"
   @topic_b "persistent://public/default/broadway-multi-topic-b"
   @partitioned_topic "persistent://public/default/broadway-failover-partitioned"
+  @ownership_topic "persistent://public/default/broadway-consumer-ownership"
+  @exclusive_topic "persistent://public/default/broadway-exclusive-ownership"
   @partition_count 2
   @message_count 100
   @multi_topic_message_count 20
@@ -22,6 +24,8 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     :ok = System.create_topic(@topic_a)
     :ok = System.create_topic(@topic_b)
     :ok = System.create_partitioned_topic(@partitioned_topic, @partition_count)
+    :ok = System.create_topic(@ownership_topic)
+    :ok = System.create_topic(@exclusive_topic)
 
     {:ok, _client_pid} =
       Pulsar.Client.start_link(
@@ -389,6 +393,185 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
 
     assert MapSet.new(topics) == MapSet.new(expected_topics)
     assert :ok = Broadway.stop(pipeline)
+  end
+
+  describe "consumer ownership" do
+    test "consumers go down with the pipeline that started them" do
+      subscription = "ownership-shutdown-sub"
+
+      {:ok, broadway} =
+        DummyPipeline.start_link(
+          test_pid: self(),
+          topic: @topic,
+          subscription: subscription,
+          client: @client,
+          name: :ownership_shutdown_pipeline,
+          flow_initial: 5,
+          flow_threshold: 2,
+          flow_refill: 5
+        )
+
+      assert_receive {:message_handled, %Broadway.Message{}, _processor}, 10_000
+
+      assert [root] = consumer_roots(subscription)
+      ref = Process.monitor(root)
+
+      assert :ok = Broadway.stop(broadway)
+
+      # Not merely deregistered: the consumer is gone, so it holds no subscription and
+      # receives no delivery it can no longer acknowledge.
+      assert_receive {:DOWN, ^ref, :process, ^root, _reason}, 5_000
+      assert wait_until(fn -> consumer_roots(subscription) == [] end, 5_000)
+    end
+
+    test "each producer stage owns its own consumers" do
+      subscription = "ownership-concurrency-sub"
+
+      {:ok, broadway} =
+        DummyPipeline.start_link(
+          test_pid: self(),
+          topic: @topic,
+          subscription: subscription,
+          client: @client,
+          name: :ownership_concurrency_pipeline,
+          producer_concurrency: 3,
+          flow_initial: 5,
+          flow_threshold: 2,
+          flow_refill: 5
+        )
+
+      roots = consumer_roots(subscription)
+      assert length(roots) == 3
+
+      assert :ok = Broadway.stop(broadway)
+
+      assert wait_until(fn -> consumer_roots(subscription) == [] end, 5_000)
+      refute Enum.any?(roots, &Process.alive?/1)
+    end
+
+    @tag :capture_log
+    test "a pipeline that cannot subscribe recovers once the subscription is free" do
+      subscription = "exclusive-ownership-sub"
+      consumer_opts = [subscription_type: :exclusive, initial_position: :earliest]
+
+      {:ok, producer} =
+        Pulsar.Producer.start_link(topic: @exclusive_topic, client: @client, name: :exclusive_ownership_producer)
+
+      :ok = Pulsar.Producer.await_ready(producer)
+
+      {:ok, holder} =
+        DummyPipeline.start_link(
+          test_pid: self(),
+          topic: @exclusive_topic,
+          subscription: subscription,
+          client: @client,
+          name: :exclusive_holder_pipeline,
+          consumer_opts: consumer_opts
+        )
+
+      {:ok, _msg_id} = Pulsar.Producer.send(producer, "held")
+      assert_receive {:message_handled, %Broadway.Message{data: "held"}, _processor}, 10_000
+
+      # The broker answers this one with :ConsumerBusy, which the client refuses to retry:
+      # the worker stops, its group with it, and the root stays up with nothing under it.
+      {:ok, waiting} =
+        DummyPipeline.start_link(
+          test_pid: self(),
+          topic: @exclusive_topic,
+          subscription: subscription,
+          client: @client,
+          name: :exclusive_waiting_pipeline,
+          consumer_opts: consumer_opts
+        )
+
+      assert :ok = Broadway.stop(holder)
+
+      {:ok, _msg_id} = Pulsar.Producer.send(producer, "free")
+
+      # The stage notices it has no consumer, stops, and Broadway starts it again — so the
+      # subscription being taken is a delay rather than a pipeline that is up and silent.
+      assert_receive {:message_handled, %Broadway.Message{data: "free"}, _processor}, 30_000
+      assert Process.alive?(waiting)
+
+      assert :ok = Broadway.stop(waiting)
+    end
+
+    @tag :capture_log
+    test "a pipeline rebuilds its consumers when the client's consumer registry is replaced" do
+      subscription = "registry-replacement-sub"
+
+      {:ok, producer} =
+        Pulsar.Producer.start_link(topic: @ownership_topic, client: @client, name: :ownership_producer)
+
+      :ok = Pulsar.Producer.await_ready(producer)
+
+      {:ok, broadway} =
+        DummyPipeline.start_link(
+          test_pid: self(),
+          topic: @ownership_topic,
+          subscription: subscription,
+          client: @client,
+          name: :registry_replacement_pipeline
+        )
+
+      {:ok, _msg_id} = Pulsar.Producer.send(producer, "before")
+      assert_receive {:message_handled, %Broadway.Message{data: "before"}, _processor}, 10_000
+
+      assert [root] = consumer_roots(subscription)
+
+      # The consumer branch is :rest_for_one, so its registry taking the branch with it is
+      # what a client restart looks like from here. A root is a supervisor, so it survives
+      # the registry that linked it — alive, unregistered, and reported by nothing.
+      registry = Pulsar.Client.registry(:consumers, @client)
+      :ok = Supervisor.stop(Process.whereis(registry), :shutdown)
+      assert wait_until(fn -> Process.whereis(registry) end, 10_000)
+
+      replacement = wait_until(fn -> Enum.find(consumer_roots(subscription), &(&1 != root)) end, 20_000)
+
+      assert is_pid(replacement)
+      refute Process.alive?(root)
+
+      {:ok, _msg_id} = Pulsar.Producer.send(producer, "after")
+      assert_receive {:message_handled, %Broadway.Message{data: "after"}, _processor}, 10_000
+
+      assert :ok = Broadway.stop(broadway)
+    end
+  end
+
+  # The stable roots this pipeline registered, read from the client's consumer registry:
+  # started with start_link/1, they are owned by their producer stage rather than by the
+  # client's DynamicSupervisor, so Pulsar.Client.consumers/1 does not list them.
+  defp consumer_roots(subscription) do
+    :consumers
+    |> Pulsar.Client.registry(@client)
+    |> Registry.select([{{:"$1", :"$2", :_}, [], [{{:"$1", :"$2"}}]}])
+    |> Enum.filter(fn {name, _pid} -> String.contains?(name, subscription) end)
+    |> Enum.map(fn {_name, pid} -> pid end)
+  rescue
+    # The registry is being replaced; nothing is registered while it is away.
+    ArgumentError -> []
+  end
+
+  # Answers with whatever `fun` last returned, so a caller asserts on the result rather than
+  # on having waited.
+  defp wait_until(fun, timeout) do
+    wait_until(fun, timeout, System.monotonic_time(:millisecond) + timeout)
+  end
+
+  defp wait_until(fun, timeout, deadline) do
+    result = fun.()
+
+    cond do
+      result ->
+        result
+
+      System.monotonic_time(:millisecond) >= deadline ->
+        result
+
+      true ->
+        Process.sleep(200)
+        wait_until(fun, timeout, deadline)
+    end
   end
 
   defp await_failover_states(states, subscription) do

--- a/test/integration/producer_test.exs
+++ b/test/integration/producer_test.exs
@@ -418,8 +418,6 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
 
       assert :ok = Broadway.stop(broadway)
 
-      # Not merely deregistered: the consumer is gone, so it holds no subscription and
-      # receives no delivery it can no longer acknowledge.
       assert_receive {:DOWN, ^ref, :process, ^root, _reason}, 5_000
       assert wait_until(fn -> consumer_roots(subscription) == [] end, 5_000)
     end
@@ -472,8 +470,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
       {:ok, _msg_id} = Pulsar.Producer.send(producer, "held")
       assert_receive {:message_handled, %Broadway.Message{data: "held"}, _processor}, 10_000
 
-      # The broker answers this one with :ConsumerBusy, which the client refuses to retry:
-      # the worker stops, its group with it, and the root stays up with nothing under it.
+      # :ConsumerBusy stops the group before its worker reports ready to the stage.
       {:ok, waiting} =
         DummyPipeline.start_link(
           test_pid: self(),
@@ -488,8 +485,6 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
 
       {:ok, _msg_id} = Pulsar.Producer.send(producer, "free")
 
-      # The stage notices it has no consumer, stops, and Broadway starts it again — so the
-      # subscription being taken is a delay rather than a pipeline that is up and silent.
       assert_receive {:message_handled, %Broadway.Message{data: "free"}, _processor}, 30_000
       assert Process.alive?(waiting)
 
@@ -516,8 +511,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
 
       assert [root] = consumer_roots(subscription)
 
-      # Pulsar.Consumer.stop/2 exits the root :normal, which the link does not carry to a
-      # stage that does not trap exits. Nothing but the stage's own check reports this.
+      # A monitor reports the normal exit that the link does not propagate.
       assert :ok = Pulsar.Consumer.stop(root, client: @client)
 
       replacement = wait_until(fn -> Enum.find(consumer_roots(subscription), &(&1 != root)) end, 20_000)
@@ -552,9 +546,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
 
       assert [root] = consumer_roots(subscription)
 
-      # The consumer branch is :rest_for_one, so its registry taking the branch with it is
-      # what a client restart looks like from here. A root is a supervisor, so it survives
-      # the registry that linked it — alive, unregistered, and reported by nothing.
+      # Replacing the Registry restarts the client's consumer branch.
       registry = Pulsar.Client.registry(:consumers, @client)
       :ok = Supervisor.stop(Process.whereis(registry), :shutdown)
       assert wait_until(fn -> Process.whereis(registry) end, 10_000)
@@ -571,9 +563,6 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     end
   end
 
-  # The stable roots this pipeline registered, read from the client's consumer registry:
-  # started with start_link/1, they are owned by their producer stage rather than by the
-  # client's DynamicSupervisor, so Pulsar.Client.consumers/1 does not list them.
   defp consumer_roots(subscription) do
     :consumers
     |> Pulsar.Client.registry(@client)
@@ -581,17 +570,14 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     |> Enum.filter(fn {name, _pid} -> String.contains?(name, subscription) end)
     |> Enum.map(fn {_name, pid} -> pid end)
   rescue
-    # The registry is being replaced; nothing is registered while it is away.
     ArgumentError -> []
   end
 
-  # Answers with whatever `fun` last returned, so a caller asserts on the result rather than
-  # on having waited.
   defp wait_until(fun, timeout) do
-    wait_until(fun, timeout, System.monotonic_time(:millisecond) + timeout)
+    do_wait_until(fun, System.monotonic_time(:millisecond) + timeout)
   end
 
-  defp wait_until(fun, timeout, deadline) do
+  defp do_wait_until(fun, deadline) do
     result = fun.()
 
     cond do
@@ -603,7 +589,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
 
       true ->
         Process.sleep(200)
-        wait_until(fun, timeout, deadline)
+        do_wait_until(fun, deadline)
     end
   end
 

--- a/test/integration/producer_test.exs
+++ b/test/integration/producer_test.exs
@@ -448,6 +448,38 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
       assert :ok = Broadway.stop(broadway)
     end
 
+    test "a normally stopped producer stage does not leave its consumer root behind" do
+      subscription = "normal-producer-stop-sub"
+      producer = start_ready_producer(:normal_producer_stop_producer, @ownership_topic)
+
+      {:ok, broadway} =
+        start_pipeline(:normal_producer_stop_pipeline, @ownership_topic, subscription)
+
+      assert [root] = consumer_roots(subscription)
+      root_ref = Process.monitor(root)
+
+      [producer_name] = Broadway.producer_names(:normal_producer_stop_pipeline)
+      stage = GenServer.whereis(producer_name)
+      assert is_pid(stage)
+      stage_ref = Process.monitor(stage)
+
+      assert :ok = GenStage.stop(stage)
+      assert_receive {:DOWN, ^stage_ref, :process, ^stage, :normal}, 5_000
+      assert_receive {:DOWN, ^root_ref, :process, ^root, :normal}, 5_000
+
+      replacement_stage = wait_for_replacement_process(producer_name, stage, 5_000)
+      replacement_root = wait_for_replacement_root(subscription, root, 20_000)
+      assert is_pid(replacement_stage)
+      assert is_pid(replacement_root)
+
+      {:ok, _msg_id} = Pulsar.Producer.send(producer, "after normal restart")
+
+      assert_receive {:message_handled, %Broadway.Message{data: "after normal restart"}, _processor},
+                     10_000
+
+      assert :ok = Broadway.stop(broadway)
+    end
+
     test "each producer stage owns its own consumers" do
       subscription = "ownership-concurrency-sub"
 

--- a/test/integration/producer_test.exs
+++ b/test/integration/producer_test.exs
@@ -497,6 +497,39 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     end
 
     @tag :capture_log
+    test "a consumer stopped through the client is rebuilt by its stage" do
+      subscription = "consumer-stop-sub"
+
+      {:ok, producer} =
+        Pulsar.Producer.start_link(topic: @ownership_topic, client: @client, name: :consumer_stop_producer)
+
+      :ok = Pulsar.Producer.await_ready(producer)
+
+      {:ok, broadway} =
+        DummyPipeline.start_link(
+          test_pid: self(),
+          topic: @ownership_topic,
+          subscription: subscription,
+          client: @client,
+          name: :consumer_stop_pipeline
+        )
+
+      assert [root] = consumer_roots(subscription)
+
+      # Pulsar.Consumer.stop/2 exits the root :normal, which the link does not carry to a
+      # stage that does not trap exits. Nothing but the stage's own check reports this.
+      assert :ok = Pulsar.Consumer.stop(root, client: @client)
+
+      replacement = wait_until(fn -> Enum.find(consumer_roots(subscription), &(&1 != root)) end, 20_000)
+      assert is_pid(replacement)
+
+      {:ok, _msg_id} = Pulsar.Producer.send(producer, "rebuilt")
+      assert_receive {:message_handled, %Broadway.Message{data: "rebuilt"}, _processor}, 10_000
+
+      assert :ok = Broadway.stop(broadway)
+    end
+
+    @tag :capture_log
     test "a pipeline rebuilds its consumers when the client's consumer registry is replaced" do
       subscription = "registry-replacement-sub"
 

--- a/test/integration/producer_test.exs
+++ b/test/integration/producer_test.exs
@@ -400,12 +400,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
       subscription = "ownership-shutdown-sub"
 
       {:ok, broadway} =
-        DummyPipeline.start_link(
-          test_pid: self(),
-          topic: @topic,
-          subscription: subscription,
-          client: @client,
-          name: :ownership_shutdown_pipeline,
+        start_pipeline(:ownership_shutdown_pipeline, @topic, subscription,
           flow_initial: 5,
           flow_threshold: 2,
           flow_refill: 5
@@ -422,16 +417,42 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
       assert wait_until(fn -> consumer_roots(subscription) == [] end, 5_000)
     end
 
+    @tag :capture_log
+    test "a producer-stage restart replaces its consumer root without leaving an orphan" do
+      subscription = "producer-restart-sub"
+      producer = start_ready_producer(:producer_restart_producer, @ownership_topic)
+
+      {:ok, broadway} =
+        start_pipeline(:producer_restart_pipeline, @ownership_topic, subscription)
+
+      assert [root] = consumer_roots(subscription)
+      root_ref = Process.monitor(root)
+
+      [producer_name] = Broadway.producer_names(:producer_restart_pipeline)
+      stage = GenServer.whereis(producer_name)
+      assert is_pid(stage)
+      stage_ref = Process.monitor(stage)
+      Process.exit(stage, :kill)
+
+      assert_receive {:DOWN, ^stage_ref, :process, ^stage, :killed}, 5_000
+      assert_receive {:DOWN, ^root_ref, :process, ^root, _}, 5_000
+
+      replacement_stage = wait_for_replacement_process(producer_name, stage, 5_000)
+      replacement_root = wait_for_replacement_root(subscription, root, 20_000)
+      assert is_pid(replacement_stage)
+      assert is_pid(replacement_root)
+
+      {:ok, _msg_id} = Pulsar.Producer.send(producer, "after restart")
+      assert_receive {:message_handled, %Broadway.Message{data: "after restart"}, _processor}, 10_000
+
+      assert :ok = Broadway.stop(broadway)
+    end
+
     test "each producer stage owns its own consumers" do
       subscription = "ownership-concurrency-sub"
 
       {:ok, broadway} =
-        DummyPipeline.start_link(
-          test_pid: self(),
-          topic: @topic,
-          subscription: subscription,
-          client: @client,
-          name: :ownership_concurrency_pipeline,
+        start_pipeline(:ownership_concurrency_pipeline, @topic, subscription,
           producer_concurrency: 3,
           flow_initial: 5,
           flow_threshold: 2,
@@ -448,44 +469,37 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     end
 
     @tag :capture_log
-    test "a pipeline that cannot subscribe recovers once the subscription is free" do
+    test "a terminal subscription failure replaces its root once the subscription is free" do
       subscription = "exclusive-ownership-sub"
       consumer_opts = [subscription_type: :exclusive, initial_position: :earliest]
-
-      {:ok, producer} =
-        Pulsar.Producer.start_link(topic: @exclusive_topic, client: @client, name: :exclusive_ownership_producer)
-
-      :ok = Pulsar.Producer.await_ready(producer)
+      producer = start_ready_producer(:exclusive_ownership_producer, @exclusive_topic)
 
       {:ok, holder} =
-        DummyPipeline.start_link(
-          test_pid: self(),
-          topic: @exclusive_topic,
-          subscription: subscription,
-          client: @client,
-          name: :exclusive_holder_pipeline,
-          consumer_opts: consumer_opts
-        )
+        start_pipeline(:exclusive_holder_pipeline, @exclusive_topic, subscription, consumer_opts: consumer_opts)
 
       {:ok, _msg_id} = Pulsar.Producer.send(producer, "held")
       assert_receive {:message_handled, %Broadway.Message{data: "held"}, _processor}, 10_000
+      assert [holder_root] = consumer_roots(subscription)
 
       # :ConsumerBusy stops the group before its worker reports ready to the stage.
       {:ok, waiting} =
-        DummyPipeline.start_link(
-          test_pid: self(),
-          topic: @exclusive_topic,
-          subscription: subscription,
-          client: @client,
-          name: :exclusive_waiting_pipeline,
-          consumer_opts: consumer_opts
-        )
+        start_pipeline(:exclusive_waiting_pipeline, @exclusive_topic, subscription, consumer_opts: consumer_opts)
+
+      blocked_root = wait_for_other_root(subscription, holder_root, 5_000)
+      assert is_pid(blocked_root)
+      blocked_ref = Process.monitor(blocked_root)
+      assert wait_until(fn -> stopped_group?(blocked_root) end, 4_000)
+      holder_ref = Process.monitor(holder_root)
 
       assert :ok = Broadway.stop(holder)
+      assert_receive {:DOWN, ^holder_ref, :process, ^holder_root, _}, 5_000
+      assert_receive {:DOWN, ^blocked_ref, :process, ^blocked_root, _}, 10_000
 
       {:ok, _msg_id} = Pulsar.Producer.send(producer, "free")
 
       assert_receive {:message_handled, %Broadway.Message{data: "free"}, _processor}, 30_000
+      replacement_root = wait_for_replacement_root(subscription, blocked_root, 5_000)
+      assert is_pid(replacement_root)
       assert Process.alive?(waiting)
 
       assert :ok = Broadway.stop(waiting)
@@ -494,27 +508,17 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     @tag :capture_log
     test "a consumer stopped through the client is rebuilt by its stage" do
       subscription = "consumer-stop-sub"
-
-      {:ok, producer} =
-        Pulsar.Producer.start_link(topic: @ownership_topic, client: @client, name: :consumer_stop_producer)
-
-      :ok = Pulsar.Producer.await_ready(producer)
+      producer = start_ready_producer(:consumer_stop_producer, @ownership_topic)
 
       {:ok, broadway} =
-        DummyPipeline.start_link(
-          test_pid: self(),
-          topic: @ownership_topic,
-          subscription: subscription,
-          client: @client,
-          name: :consumer_stop_pipeline
-        )
+        start_pipeline(:consumer_stop_pipeline, @ownership_topic, subscription)
 
       assert [root] = consumer_roots(subscription)
 
       # A monitor reports the normal exit that the link does not propagate.
       assert :ok = Pulsar.Consumer.stop(root, client: @client)
 
-      replacement = wait_until(fn -> Enum.find(consumer_roots(subscription), &(&1 != root)) end, 20_000)
+      replacement = wait_for_replacement_root(subscription, root, 20_000)
       assert is_pid(replacement)
 
       {:ok, _msg_id} = Pulsar.Producer.send(producer, "rebuilt")
@@ -526,20 +530,10 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     @tag :capture_log
     test "consumer roots survive replacement of the client's consumer Registry" do
       subscription = "registry-replacement-sub"
-
-      {:ok, producer} =
-        Pulsar.Producer.start_link(topic: @ownership_topic, client: @client, name: :ownership_producer)
-
-      :ok = Pulsar.Producer.await_ready(producer)
+      producer = start_ready_producer(:ownership_producer, @ownership_topic)
 
       {:ok, broadway} =
-        DummyPipeline.start_link(
-          test_pid: self(),
-          topic: @ownership_topic,
-          subscription: subscription,
-          client: @client,
-          name: :registry_replacement_pipeline
-        )
+        start_pipeline(:registry_replacement_pipeline, @ownership_topic, subscription)
 
       assert [root] = consumer_roots(subscription)
       assert :ok = Pulsar.Consumer.await_ready(root)
@@ -559,6 +553,17 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     end
   end
 
+  defp start_pipeline(name, topic, subscription, opts \\ []) do
+    defaults = [test_pid: self(), topic: topic, subscription: subscription, client: @client, name: name]
+    DummyPipeline.start_link(Keyword.merge(defaults, opts))
+  end
+
+  defp start_ready_producer(name, topic) do
+    {:ok, producer} = Pulsar.Producer.start_link(topic: topic, client: @client, name: name)
+    :ok = Pulsar.Producer.await_ready(producer)
+    producer
+  end
+
   defp consumer_roots(subscription) do
     :consumers
     |> Pulsar.Client.registry(@client)
@@ -571,6 +576,42 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
 
   defp wait_until(fun, timeout) do
     do_wait_until(fun, System.monotonic_time(:millisecond) + timeout)
+  end
+
+  defp wait_for_replacement_process(name, old_pid, timeout) do
+    wait_until(
+      fn ->
+        case GenServer.whereis(name) do
+          pid when is_pid(pid) and pid != old_pid -> pid
+          _other -> false
+        end
+      end,
+      timeout
+    )
+  end
+
+  defp wait_for_replacement_root(subscription, old_root, timeout) do
+    wait_until(
+      fn ->
+        case consumer_roots(subscription) do
+          [root] when root != old_root -> root
+          _roots -> false
+        end
+      end,
+      timeout
+    )
+  end
+
+  defp wait_for_other_root(subscription, root, timeout) do
+    wait_until(fn -> Enum.find(consumer_roots(subscription), &(&1 != root)) end, timeout)
+  end
+
+  defp stopped_group?(root) do
+    root
+    |> Supervisor.which_children()
+    |> Enum.any?(fn {_id, pid, _type, _modules} -> pid == :undefined end)
+  catch
+    :exit, _reason -> false
   end
 
   defp do_wait_until(fun, deadline) do

--- a/test/integration/producer_test.exs
+++ b/test/integration/producer_test.exs
@@ -524,7 +524,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     end
 
     @tag :capture_log
-    test "a pipeline rebuilds its consumers when the client's consumer registry is replaced" do
+    test "consumer roots survive replacement of the client's consumer Registry" do
       subscription = "registry-replacement-sub"
 
       {:ok, producer} =
@@ -541,20 +541,16 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
           name: :registry_replacement_pipeline
         )
 
-      {:ok, _msg_id} = Pulsar.Producer.send(producer, "before")
-      assert_receive {:message_handled, %Broadway.Message{data: "before"}, _processor}, 10_000
-
       assert [root] = consumer_roots(subscription)
+      assert :ok = Pulsar.Consumer.await_ready(root)
 
-      # Replacing the Registry restarts the client's consumer branch.
       registry = Pulsar.Client.registry(:consumers, @client)
-      :ok = Supervisor.stop(Process.whereis(registry), :shutdown)
-      assert wait_until(fn -> Process.whereis(registry) end, 10_000)
-
-      replacement = wait_until(fn -> Enum.find(consumer_roots(subscription), &(&1 != root)) end, 20_000)
-
-      assert is_pid(replacement)
-      refute Process.alive?(root)
+      old_registry = Process.whereis(registry)
+      :ok = Supervisor.stop(old_registry, :shutdown)
+      replacement_registry = wait_until(fn -> Process.whereis(registry) end, 10_000)
+      assert is_pid(replacement_registry)
+      assert replacement_registry != old_registry
+      assert Process.alive?(root)
 
       {:ok, _msg_id} = Pulsar.Producer.send(producer, "after")
       assert_receive {:message_handled, %Broadway.Message{data: "after"}, _processor}, 10_000

--- a/test/off_broadway/pulsar/producer_test.exs
+++ b/test/off_broadway/pulsar/producer_test.exs
@@ -34,9 +34,6 @@ defmodule OffBroadway.Pulsar.ProducerTest do
     end
 
     test "validates flow options before starting any consumer" do
-      # A registered name is all ensure_client_running!/1 checks. Were the flow options
-      # validated later, this would fail on the client's consumer registry being absent
-      # instead, which says nothing about the option that is actually wrong.
       start_supervised!(%{
         id: :fake_client,
         start: {Agent, :start_link, [fn -> :ok end, [name: :fake_client]]}
@@ -199,14 +196,6 @@ defmodule OffBroadway.Pulsar.ProducerTest do
   end
 
   describe "consumer ownership" do
-    test "stops when the consumer Registry exits" do
-      monitor_ref = make_ref()
-      state = %{state() | registry_monitor: {self(), monitor_ref}}
-
-      assert {:stop, {:shutdown, {:consumer_registry_down, :default}}, _state} =
-               Producer.handle_info({:DOWN, monitor_ref, :process, self(), :shutdown}, state)
-    end
-
     test "stops when a consumer root exits normally" do
       monitor_ref = make_ref()
       state = %{state() | consumer_roots: %{self() => {"topic", monitor_ref}}}
@@ -258,8 +247,6 @@ defmodule OffBroadway.Pulsar.ProducerTest do
     %{
       consumers: %{self() => {"topic", 10}},
       consumer_roots: %{},
-      client: :default,
-      registry_monitor: nil,
       demand: 10,
       buffer: [],
       flow_initial: 10,

--- a/test/off_broadway/pulsar/producer_test.exs
+++ b/test/off_broadway/pulsar/producer_test.exs
@@ -259,11 +259,15 @@ defmodule OffBroadway.Pulsar.ProducerTest do
                Producer.handle_info(:check_consumers, state)
     end
 
-    test "the health check tolerates a root that is already gone" do
+    test "the health check stops when a root is gone, however it went" do
       %{state: state} = healthy_consumer()
+
+      # Pulsar.Consumer.stop/2 ends at Supervisor.stop/1, which exits :normal — a signal a
+      # stage that does not trap exits ignores, so the link never answers for this one.
       :ok = stop_supervised!(:root)
 
-      assert {:noreply, [], _state} = Producer.handle_info(:check_consumers, state)
+      assert {:stop, {:shutdown, {:consumer_gone, "topic"}}, _state} =
+               Producer.handle_info(:check_consumers, state)
     end
   end
 

--- a/test/off_broadway/pulsar/producer_test.exs
+++ b/test/off_broadway/pulsar/producer_test.exs
@@ -199,33 +199,23 @@ defmodule OffBroadway.Pulsar.ProducerTest do
   end
 
   describe "consumer ownership" do
-    test "stops when a known worker fails on an error the client will not retry" do
-      reason = {:ConsumerBusy, "Exclusive consumer is already connected"}
+    test "stops when the consumer Registry exits" do
+      monitor_ref = make_ref()
+      state = %{state() | registry_monitor: {self(), monitor_ref}}
 
-      assert {:stop, {:shutdown, {:consumer_terminal_error, "topic", ^reason}}, _state} =
-               Producer.handle_info({:DOWN, make_ref(), :process, self(), {:shutdown, reason}}, state())
+      assert {:stop, {:shutdown, {:consumer_registry_down, :default}}, _state} =
+               Producer.handle_info({:DOWN, monitor_ref, :process, self(), :shutdown}, state)
     end
 
-    test "keeps running when a worker it does not know stops terminally" do
-      state = %{state() | consumers: %{}}
+    test "stops when a consumer root exits normally" do
+      monitor_ref = make_ref()
+      state = %{state() | consumer_roots: %{self() => {"topic", monitor_ref}}}
 
-      assert {:noreply, [], new_state} =
-               Producer.handle_info(
-                 {:DOWN, make_ref(), :process, self(), {:shutdown, {:TopicNotFound, "gone"}}},
-                 state
-               )
-
-      assert new_state.consumers == %{}
+      assert {:stop, {:shutdown, {:consumer_gone, "topic"}}, _state} =
+               Producer.handle_info({:DOWN, monitor_ref, :process, self(), :normal}, state)
     end
 
-    test "keeps running when a worker crashes for a reason the client retries" do
-      assert {:noreply, [], new_state} =
-               Producer.handle_info({:DOWN, make_ref(), :process, self(), :broker_crashed}, state())
-
-      assert new_state.consumers == %{}
-    end
-
-    test "the health check leaves a registered consumer whose groups are all running alone" do
+    test "the health check leaves a running consumer alone" do
       %{root: root, state: state} = healthy_consumer()
 
       assert {:noreply, [], _state} = Producer.handle_info(:check_consumers, state)
@@ -235,55 +225,22 @@ defmodule OffBroadway.Pulsar.ProducerTest do
     test "the health check stops when a consumer has a group the client gave up on" do
       %{root: root, state: state} = healthy_consumer()
 
-      # What a worker stopping with {:shutdown, terminal_reason} leaves behind: a group that
-      # exited cleanly and a root that keeps the child registered without a pid.
       [{_id, group, _type, _modules}] = Supervisor.which_children(root)
       :ok = Agent.stop(group)
 
       assert {:stop, {:shutdown, {:consumer_stopped, "topic"}}, _state} =
                Producer.handle_info(:check_consumers, state)
     end
-
-    test "the health check stops when the consumer's registration is no longer its own" do
-      %{state: state} = healthy_consumer()
-
-      # A replaced registry comes back under the same name and without the entries: the root
-      # is a supervisor, so it survives the registry it was linked to and never re-registers.
-      :ok = stop_supervised!(:registry)
-
-      start_supervised!({Registry, keys: :unique, name: Pulsar.Client.registry(:consumers, :health_client)},
-        id: :registry
-      )
-
-      assert {:stop, {:shutdown, {:consumer_unregistered, "topic"}}, _state} =
-               Producer.handle_info(:check_consumers, state)
-    end
-
-    test "the health check stops when a root is gone, however it went" do
-      %{state: state} = healthy_consumer()
-
-      # Pulsar.Consumer.stop/2 ends at Supervisor.stop/1, which exits :normal — a signal a
-      # stage that does not trap exits ignores, so the link never answers for this one.
-      :ok = stop_supervised!(:root)
-
-      assert {:stop, {:shutdown, {:consumer_gone, "topic"}}, _state} =
-               Producer.handle_info(:check_consumers, state)
-    end
   end
 
-  # A registered consumer root as Pulsar builds one: a supervisor named through the client's
-  # consumer registry, holding one group child per topic or partition.
   defp healthy_consumer do
-    client = :health_client
-    registry = Pulsar.Client.registry(:consumers, client)
-    start_supervised!({Registry, keys: :unique, name: registry}, id: :registry)
+    root = start_supervised!(consumer_root_spec())
+    monitor_ref = Process.monitor(root)
 
-    root = start_supervised!(consumer_root_spec(registry, "topic-sub-1"))
-
-    %{root: root, state: %{state() | consumer_roots: %{root => {"topic", "topic-sub-1"}}, client: client}}
+    %{root: root, state: %{state() | consumer_roots: %{root => {"topic", monitor_ref}}}}
   end
 
-  defp consumer_root_spec(registry, name) do
+  defp consumer_root_spec do
     group = %{
       id: {:topic, :non_partitioned},
       start: {Agent, :start_link, [fn -> :ok end]},
@@ -292,7 +249,7 @@ defmodule OffBroadway.Pulsar.ProducerTest do
 
     %{
       id: :root,
-      start: {Supervisor, :start_link, [[group], [strategy: :one_for_one, name: {:via, Registry, {registry, name}}]]},
+      start: {Supervisor, :start_link, [[group], [strategy: :one_for_one]]},
       type: :supervisor
     }
   end
@@ -302,6 +259,7 @@ defmodule OffBroadway.Pulsar.ProducerTest do
       consumers: %{self() => {"topic", 10}},
       consumer_roots: %{},
       client: :default,
+      registry_monitor: nil,
       demand: 10,
       buffer: [],
       flow_initial: 10,

--- a/test/off_broadway/pulsar/producer_test.exs
+++ b/test/off_broadway/pulsar/producer_test.exs
@@ -35,8 +35,8 @@ defmodule OffBroadway.Pulsar.ProducerTest do
 
     test "validates flow options before starting any consumer" do
       # A registered name is all ensure_client_running!/1 checks. Were the flow options
-      # validated after the consumers are started, this would fail with a MatchError on
-      # Pulsar.Consumer.start/1's {:error, :client_not_found} instead.
+      # validated later, this would fail on the client's consumer registry being absent
+      # instead, which says nothing about the option that is actually wrong.
       start_supervised!(%{
         id: :fake_client,
         start: {Agent, :start_link, [fn -> :ok end, [name: :fake_client]]}
@@ -198,9 +198,106 @@ defmodule OffBroadway.Pulsar.ProducerTest do
     end
   end
 
+  describe "consumer ownership" do
+    test "stops when a known worker fails on an error the client will not retry" do
+      reason = {:ConsumerBusy, "Exclusive consumer is already connected"}
+
+      assert {:stop, {:shutdown, {:consumer_terminal_error, "topic", ^reason}}, _state} =
+               Producer.handle_info({:DOWN, make_ref(), :process, self(), {:shutdown, reason}}, state())
+    end
+
+    test "keeps running when a worker it does not know stops terminally" do
+      state = %{state() | consumers: %{}}
+
+      assert {:noreply, [], new_state} =
+               Producer.handle_info(
+                 {:DOWN, make_ref(), :process, self(), {:shutdown, {:TopicNotFound, "gone"}}},
+                 state
+               )
+
+      assert new_state.consumers == %{}
+    end
+
+    test "keeps running when a worker crashes for a reason the client retries" do
+      assert {:noreply, [], new_state} =
+               Producer.handle_info({:DOWN, make_ref(), :process, self(), :broker_crashed}, state())
+
+      assert new_state.consumers == %{}
+    end
+
+    test "the health check leaves a registered consumer whose groups are all running alone" do
+      %{root: root, state: state} = healthy_consumer()
+
+      assert {:noreply, [], _state} = Producer.handle_info(:check_consumers, state)
+      assert Process.alive?(root)
+    end
+
+    test "the health check stops when a consumer has a group the client gave up on" do
+      %{root: root, state: state} = healthy_consumer()
+
+      # What a worker stopping with {:shutdown, terminal_reason} leaves behind: a group that
+      # exited cleanly and a root that keeps the child registered without a pid.
+      [{_id, group, _type, _modules}] = Supervisor.which_children(root)
+      :ok = Agent.stop(group)
+
+      assert {:stop, {:shutdown, {:consumer_stopped, "topic"}}, _state} =
+               Producer.handle_info(:check_consumers, state)
+    end
+
+    test "the health check stops when the consumer's registration is no longer its own" do
+      %{state: state} = healthy_consumer()
+
+      # A replaced registry comes back under the same name and without the entries: the root
+      # is a supervisor, so it survives the registry it was linked to and never re-registers.
+      :ok = stop_supervised!(:registry)
+
+      start_supervised!({Registry, keys: :unique, name: Pulsar.Client.registry(:consumers, :health_client)},
+        id: :registry
+      )
+
+      assert {:stop, {:shutdown, {:consumer_unregistered, "topic"}}, _state} =
+               Producer.handle_info(:check_consumers, state)
+    end
+
+    test "the health check tolerates a root that is already gone" do
+      %{state: state} = healthy_consumer()
+      :ok = stop_supervised!(:root)
+
+      assert {:noreply, [], _state} = Producer.handle_info(:check_consumers, state)
+    end
+  end
+
+  # A registered consumer root as Pulsar builds one: a supervisor named through the client's
+  # consumer registry, holding one group child per topic or partition.
+  defp healthy_consumer do
+    client = :health_client
+    registry = Pulsar.Client.registry(:consumers, client)
+    start_supervised!({Registry, keys: :unique, name: registry}, id: :registry)
+
+    root = start_supervised!(consumer_root_spec(registry, "topic-sub-1"))
+
+    %{root: root, state: %{state() | consumer_roots: %{root => {"topic", "topic-sub-1"}}, client: client}}
+  end
+
+  defp consumer_root_spec(registry, name) do
+    group = %{
+      id: {:topic, :non_partitioned},
+      start: {Agent, :start_link, [fn -> :ok end]},
+      restart: :transient
+    }
+
+    %{
+      id: :root,
+      start: {Supervisor, :start_link, [[group], [strategy: :one_for_one, name: {:via, Registry, {registry, name}}]]},
+      type: :supervisor
+    }
+  end
+
   defp state do
     %{
       consumers: %{self() => {"topic", 10}},
+      consumer_roots: %{},
+      client: :default,
       demand: 10,
       buffer: [],
       flow_initial: 10,


### PR DESCRIPTION
## Summary

Makes each Broadway producer stage own the Pulsar consumer roots that feed it.

- Starts consumer roots with `Pulsar.Consumer.start_link/1` and stops them explicitly during graceful stage termination, covering both abnormal and normal exits.
- Monitors consumer roots, so even a normal root exit causes Broadway to rebuild the stage and its consumers.
- Keeps a periodic health check only for terminal subscription failures that stop a consumer group while leaving its root alive.
- Documents the lifecycle boundary between Broadway and pulsar-elixir in the README.

This prevents orphaned consumers after a producer-stage restart and prevents a pipeline from remaining healthy but idle after its consumer topology stops.

Fixes #71.

## Failure propagation

| Event | Result |
| --- | --- |
| The producer stage exits | Its consumer roots stop, including when the stage exits normally |
| A consumer root exits | Its link or monitor stops the stage; Broadway recreates the stage and its roots |
| The consumer Registry is replaced | Existing roots keep running by pid, but their former names no longer resolve |
| A terminal subscription error stops a group | The health check stops the stage so Broadway can recreate the consumer |
| A retryable worker or broker failure occurs | pulsar-elixir's topology supervision handles the restart |

The `Pulsar.Client` continues to own shared infrastructure such as the Registry and broker processes. Consumer roots belong to their Broadway producer stages, so they are not children of the client's consumer `DynamicSupervisor` and do not appear in `Pulsar.Client.consumers/1`.

Stopping an individual root through `Pulsar.Consumer.stop/2` causes its owning stage to rebuild it. Stop the Broadway pipeline to stop these consumers permanently.

## Remaining coupling

The health check matches pulsar-elixir's private consumer-group child IDs. A public consumer status or terminal-failure signal upstream would remove that coupling.

## Verification

- `mix test` — 47 tests passing
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`
