### PR TITLE
refactor!: reworked option handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ children = [
 producer: [
   module: {OffBroadway.Pulsar.Producer,
     client: :analytics,
-    topic: "persistent://public/default/my-topic",
+    topics: ["persistent://public/default/my-topic"],
     subscription: "my-subscription"
   },
   concurrency: 1
@@ -94,18 +94,16 @@ producer: [
 
 ## Configuration
 
-Options accepted by the producer:
+`:topics` and `:subscription` are required. `:client` selects which running `Pulsar.Client`
+to attach to, the `:flow_*` options tune read-ahead, `:active_state_callback` observes
+failover transitions, and `:consumer_opts` is forwarded to `Pulsar.Consumer`.
 
-| Option | Default | Description |
-| --- | --- | --- |
-| `:topic` / `:topics` | — | Topic, or list of topics, to consume from. One consumer per topic; one of the two is required |
-| `:subscription` | — | Subscription name (required) |
-| `:client` | `:default` | Name of the running `Pulsar.Client` to attach to |
-| `:consumer_opts` | `[subscription_type: :shared]` | Options forwarded to `Pulsar.Consumer`, applied to every topic |
-| `:flow_initial` | `100` | Permits each consumer grants when it subscribes |
-| `:flow_threshold` | `50` | Refill once outstanding permits fall to this level; must be less than `:flow_initial` |
-| `:flow_refill` | `50` | Permits granted per refill |
-| `:active_state_callback` | `nil` | `{module, function, extra_args}` invoked on active/passive transitions of `:failover` consumers |
+Options are validated when the stage starts, so a misconfigured pipeline fails at boot rather
+than at the first message. The
+[producer documentation](https://hexdocs.pm/off_broadway_pulsar/OffBroadway.Pulsar.Producer.html#start_link/1)
+lists every option with its type and default.
+
+### Flow control
 
 The `:flow_*` options replace the consumer's own automatic refills. Each consumer grants its
 full `:flow_initial` window as soon as it subscribes — before Broadway has asked for
@@ -115,20 +113,27 @@ demand: messages delivered ahead of demand wait in the producer's buffer. Each c
 keeps its own window — one per topic, and one per partition of a partitioned topic — and
 each producer stage has its own consumers, so size `:flow_initial` with that total in mind.
 
-`:consumer_opts` forwards a fixed set of keys (subscription type, initial position, dead
-letter policy, chunking and schema settings, and others); anything outside that set is
-dropped. Setting it replaces the default rather than merging into it. The consumer's own
-`:consumer_count` and `:flow_*` options are not honored here — use Broadway's
-`producer: [concurrency: N]` and the `:flow_*` options above.
+### Consumer options
+
+`:consumer_opts` is forwarded to every consumer the stage starts.
+[`Pulsar.Consumer`](https://hexdocs.pm/pulsar_elixir/Pulsar.Consumer.html) documents and
+validates the keys it accepts, so they are deliberately not mirrored here. Setting the option
+replaces the default rather than merging into it.
+
+The keys the producer sets for itself — the topic, subscription, callback module, consumer
+count and flow settings — are rejected, each naming the option that does work instead: use
+`producer: [concurrency: N]` for the consumer count, and the `:flow_*` options above for flow
+control.
+
+### Failover active state
 
 `:active_state_callback` is invoked as `apply(module, function, [metadata | extra_args])`,
 where `metadata` carries the active state, the topic or partition, the subscription and the
 consumer pid. It runs synchronously in the Pulsar consumer, so it should return promptly.
 Reports are best-effort observations — they may repeat, and they are not a distributed lock
-or fencing mechanism.
-
-See the [producer documentation](https://hexdocs.pm/off_broadway_pulsar/OffBroadway.Pulsar.Producer.html#start_link/1)
-for the full option list and the complete callback contract.
+or fencing mechanism. The
+[producer documentation](https://hexdocs.pm/off_broadway_pulsar/OffBroadway.Pulsar.Producer.html#start_link/1)
+has the complete callback contract.
 
 ## Architecture and failure propagation
 

--- a/examples/atproto.exs
+++ b/examples/atproto.exs
@@ -263,7 +263,7 @@ defmodule ATProto.Pipeline do
       producer: [
         module:
           {OffBroadway.Pulsar.Producer,
-           topic: @topic, subscription: @subscription, consumer_opts: [initial_position: :earliest]},
+           topics: [@topic], subscription: @subscription, consumer_opts: [initial_position: :earliest]},
         concurrency: 2
       ],
       processors: [default: [concurrency: 4]],

--- a/lib/off_broadway/pulsar/producer.ex
+++ b/lib/off_broadway/pulsar/producer.ex
@@ -23,33 +23,91 @@ defmodule OffBroadway.Pulsar.Producer do
 
   require Logger
 
-  @supported_consumer_opts [
-    :subscription_type,
-    :initial_position,
-    :durable,
-    :force_create_topic,
-    :start_message_id,
-    :start_timestamp,
-    :redelivery_interval,
-    :dead_letter_policy,
-    :startup_delay_ms,
-    :startup_jitter_ms,
-    :max_pending_chunked_messages,
-    :expire_incomplete_chunked_message_after,
-    :chunk_cleanup_interval,
-    :read_compacted,
-    :batch_index_ack_enabled,
-    :schema,
-    :partition_discovery_interval_ms
-  ]
-
   @default_consumer_opts [
     subscription_type: :shared
   ]
 
-  @default_flow_initial 100
-  @default_flow_threshold 50
-  @default_flow_refill 50
+  # Keys the producer sets on every consumer it starts. A value given here would be silently
+  # discarded by the merge below, or would break the producer's own flow accounting.
+  @reserved_consumer_opts [
+    client: "it comes from the producer's own :client",
+    topic: "it comes from the producer's :topics",
+    subscription_name: "it comes from the producer's :subscription",
+    callback_module: "the producer supplies its own callback module",
+    init_args: "the producer supplies its own init args",
+    name: "consumer names are generated per producer stage",
+    consumer_count: "use Broadway's producer: [concurrency: N]",
+    flow_policy: "the producer grants refills itself",
+    flow_initial: "use the producer's own :flow_initial",
+    flow_threshold: "use the producer's own :flow_threshold",
+    flow_refill: "use the producer's own :flow_refill"
+  ]
+
+  @reserved_keys_doc @reserved_consumer_opts |> Keyword.keys() |> Enum.map_join(", ", &"`#{inspect(&1)}`")
+
+  @opts_schema [
+    client: [
+      type: :atom,
+      default: :default,
+      doc: """
+      Name of the `Pulsar.Client` to attach to. The client must already be running; see
+      "Starting a client" below.
+      """
+    ],
+    topics: [
+      type: {:custom, __MODULE__, :validate_topics, []},
+      required: true,
+      doc: """
+      The Pulsar topics to consume from, as a non-empty list of strings. One consumer is
+      started per topic.
+      """
+    ],
+    subscription: [
+      type: :string,
+      required: true,
+      doc: "The subscription name."
+    ],
+    active_state_callback: [
+      type: {:or, [:mfa, {:in, [nil]}]},
+      default: nil,
+      doc: """
+      A `{module, function, extra_args}` tuple that receives active/passive state changes for
+      Failover consumers. `nil` disables it. See "Failover Active State" below.
+      """
+    ],
+    consumer_opts: [
+      type: :keyword_list,
+      default: @default_consumer_opts,
+      doc: """
+      Options forwarded to `Pulsar.Consumer.start_link/1`, applied to every topic. They are
+      documented and validated by `Pulsar.Consumer`, which rejects unknown keys. Setting this
+      replaces the default rather than merging into it.
+
+      The keys the producer sets itself are rejected here: #{@reserved_keys_doc}. Use
+      `producer: [concurrency: N]` for the consumer count and the `:flow_*` options above for
+      flow control.
+
+      `:batch_index_ack_enabled` is worth enabling for Broadway, which routinely completes
+      messages from one batch out of order, but it requires
+      `acknowledgmentAtBatchIndexLevelEnabled=true` on the broker.
+      """
+    ],
+    flow_initial: [
+      type: :pos_integer,
+      default: 100,
+      doc: "Permits each consumer grants when it subscribes."
+    ],
+    flow_threshold: [
+      type: :pos_integer,
+      default: 50,
+      doc: "Refill once outstanding permits reach this level. Must be less than `:flow_initial`."
+    ],
+    flow_refill: [
+      type: :pos_integer,
+      default: 50,
+      doc: "Permits granted by each refill."
+    ]
+  ]
 
   # Terminal subscription errors can stop a group without stopping its root.
   @health_check_interval_ms 5_000
@@ -60,51 +118,14 @@ defmodule OffBroadway.Pulsar.Producer do
 
   ## Configuration
 
-  - `:client` - Name of the `Pulsar.Client` to attach to (optional, default: `:default`).
-    The client must already be running; see "Starting a client" below.
-  - `:topic` - A single Pulsar topic to consume from (required if `:topics` is not set)
-  - `:topics` - A list of Pulsar topics to consume from (required if `:topic` is not set).
-    One consumer is started per topic. Providing a single topic via `:topic` is equivalent
-    to `topics: [topic]` and is kept for backwards compatibility.
-  - `:subscription` - The subscription name (required)
-  - `:active_state_callback` - An optional `{module, function, extra_args}` tuple that receives
-    active/passive state changes for Failover consumers. See "Failover Active State" below.
-  - `:consumer_opts` - Consumer-specific options passed to `Pulsar.Consumer.start_link/1` (optional).
-    Applied to all topics when using `:topics`.
-    - `:subscription_type` - Subscription type (`:exclusive`, `:failover`, `:shared`, `:key_shared`, default: `:shared`)
-    - `:initial_position` - Initial position (`:latest` or `:earliest`, default: `:latest`)
-    - `:durable` - Whether subscription is durable (default: `true`)
-    - `:force_create_topic` - Force topic creation (default: `true`)
-    - `:start_message_id` - Start from specific `{ledger_id, entry_id}`
-    - `:start_timestamp` - Start from timestamp
-    - `:redelivery_interval` - Redelivery interval in milliseconds for NACKed messages
-    - `:dead_letter_policy` - Dead letter queue configuration
-    - `:startup_delay_ms` - Fixed startup delay in milliseconds before consumer initialization (default: 0)
-    - `:startup_jitter_ms` - Random startup delay (0 to N ms) to avoid thundering herd on consumer restart (default: 0)
-    - `:max_pending_chunked_messages` - Maximum number of concurrent chunked messages to buffer (default: 10)
-    - `:expire_incomplete_chunked_message_after` - Timeout in milliseconds for incomplete chunked messages (default: 60_000)
-    - `:chunk_cleanup_interval` - Interval in milliseconds for checking expired chunked messages (default: 30_000)
-    - `:read_compacted` - If true, reads messages from the compacted topic ledger (default: false)
-    - `:batch_index_ack_enabled` - Acknowledge individual messages within a batched entry rather
-      than the whole entry (default: false). Worth enabling for Broadway, which routinely
-      completes messages from one batch out of order, but it requires
-      `acknowledgmentAtBatchIndexLevelEnabled=true` on the broker
-    - `:schema` - Schema to register with the subscription, as `[type: atom, definition: term]`
-    - `:partition_discovery_interval_ms` - How often (in milliseconds) to poll for new partitions on
-      partitioned topics. Set to `false` to disable discovery (default: 60_000)
+  #{NimbleOptions.docs(@opts_schema)}
 
-  `:consumer_count` is not accepted here; use Broadway's `producer: [concurrency: N]`.
-  Nor are the consumer's own `:flow_*` options — see "Flow Control Options" below.
+  Options are validated when the stage starts, so a misconfigured pipeline fails at boot
+  rather than at the first message.
 
-  The total consumer startup delay is `startup_delay_ms + random(0, startup_jitter_ms)`, applied on every consumer start/restart.
+  ## Flow Control
 
-  ## Flow Control Options
-
-  - `:flow_initial` - Permits each consumer grants when it subscribes (optional, default: 100)
-  - `:flow_threshold` - Refill once outstanding permits reach this level (optional, default: 50)
-  - `:flow_refill` - Permits granted by each refill (optional, default: 50)
-
-  These replace the consumer's own automatic refills: the producer sets the consumer's
+  The `:flow_*` options replace the consumer's own automatic refills: the producer sets the consumer's
   `:flow_policy` to report what each delivery cost and grants the refills itself, sized to
   what Broadway has taken. Each worker still grants its full `:flow_initial` window when it
   subscribes, independently of pipeline demand, so read-ahead is bounded by the permit window
@@ -214,7 +235,7 @@ defmodule OffBroadway.Pulsar.Producer do
       producer: [
         module: {OffBroadway.Pulsar.Producer,
           client: :analytics,
-          topic: "my-topic",
+          topics: ["my-topic"],
           subscription: "my-subscription"
         }
       ]
@@ -225,39 +246,19 @@ defmodule OffBroadway.Pulsar.Producer do
 
   @impl GenStage
   def init(opts) do
-    topics =
-      cond do
-        Keyword.has_key?(opts, :topics) ->
-          Keyword.fetch!(opts, :topics)
+    opts = validate_options!(opts)
 
-        Keyword.has_key?(opts, :topic) ->
-          [Keyword.fetch!(opts, :topic)]
-
-        true ->
-          raise ArgumentError, "either :topic or :topics is required"
-      end
-
+    topics = Keyword.fetch!(opts, :topics)
     subscription = Keyword.fetch!(opts, :subscription)
-    client = Keyword.get(opts, :client, :default)
+    client = Keyword.fetch!(opts, :client)
 
-    active_state_callback = Keyword.get(opts, :active_state_callback)
+    active_state_callback = Keyword.fetch!(opts, :active_state_callback)
 
     ensure_client_running!(client)
 
-    flow_initial =
-      opts
-      |> Keyword.get(:flow_initial, @default_flow_initial)
-      |> validate_positive_integer!(:flow_initial)
-
-    flow_threshold =
-      opts
-      |> Keyword.get(:flow_threshold, @default_flow_threshold)
-      |> validate_positive_integer!(:flow_threshold)
-
-    flow_refill =
-      opts
-      |> Keyword.get(:flow_refill, @default_flow_refill)
-      |> validate_positive_integer!(:flow_refill)
+    flow_initial = Keyword.fetch!(opts, :flow_initial)
+    flow_threshold = Keyword.fetch!(opts, :flow_threshold)
+    flow_refill = Keyword.fetch!(opts, :flow_refill)
 
     if flow_threshold >= flow_initial do
       raise ArgumentError,
@@ -269,8 +270,7 @@ defmodule OffBroadway.Pulsar.Producer do
     # any. Refills are this producer's, driven by what Broadway takes.
     consumer_opts_base =
       opts
-      |> Keyword.get(:consumer_opts, @default_consumer_opts)
-      |> Keyword.take(@supported_consumer_opts)
+      |> Keyword.fetch!(:consumer_opts)
       |> Keyword.merge(
         client: client,
         flow_initial: flow_initial,
@@ -532,10 +532,38 @@ defmodule OffBroadway.Pulsar.Producer do
     end
   end
 
-  defp validate_positive_integer!(value, _name) when is_integer(value) and value > 0, do: value
+  defp validate_options!(opts) do
+    # Broadway injects :broadway (pipeline name and stage index) into the producer's options.
+    {_broadway, opts} = Keyword.pop(opts, :broadway)
 
-  defp validate_positive_integer!(value, name) do
-    raise ArgumentError,
-          "expected :#{name} to be a positive integer, got: #{inspect(value)}"
+    opts =
+      case NimbleOptions.validate(opts, @opts_schema) do
+        {:ok, opts} -> opts
+        {:error, error} -> raise ArgumentError, Exception.message(error)
+      end
+
+    consumer_opts = Keyword.fetch!(opts, :consumer_opts)
+
+    Enum.each(@reserved_consumer_opts, fn {key, reason} ->
+      if Keyword.has_key?(consumer_opts, key) do
+        raise ArgumentError, "invalid value for :consumer_opts: #{inspect(key)} cannot be set here, #{reason}"
+      end
+    end)
+
+    opts
+  end
+
+  # An empty list would leave the stage running with nothing to consume, so it is rejected
+  # here rather than by the {:list, :string} type.
+  @doc false
+  @spec validate_topics(term()) :: {:ok, [String.t()]} | {:error, String.t()}
+  def validate_topics([_ | _] = topics) do
+    if Enum.all?(topics, &is_binary/1),
+      do: {:ok, topics},
+      else: {:error, "expected a non-empty list of topic names, got: #{inspect(topics)}"}
+  end
+
+  def validate_topics(other) do
+    {:error, "expected a non-empty list of topic names, got: #{inspect(other)}"}
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -46,6 +46,7 @@ defmodule OffBroadwayPulsar.MixProject do
   defp deps do
     [
       {:broadway, "~> 1.2"},
+      {:nimble_options, "~> 1.1"},
       {:pulsar, "~> 3.0.1", hex: :pulsar_elixir},
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.4", only: [:dev, :test], runtime: false},

--- a/test/integration/partition_discovery_test.exs
+++ b/test/integration/partition_discovery_test.exs
@@ -43,7 +43,7 @@ defmodule OffBroadwayPulsar.Integration.PartitionDiscoveryTest do
     {:ok, _broadway} =
       DummyPipeline.start_link(
         test_pid: self(),
-        topic: topic,
+        topics: [topic],
         subscription: subscription,
         client: @client,
         name: String.to_atom("partition_discovery_pipeline_#{test_id}"),

--- a/test/integration/producer_test.exs
+++ b/test/integration/producer_test.exs
@@ -78,7 +78,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     {:ok, _broadway} =
       DummyPipeline.start_link(
         test_pid: self(),
-        topic: @topic,
+        topics: [@topic],
         subscription: "concurrency-sub",
         client: @client,
         producer_concurrency: 3,
@@ -103,7 +103,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     {:ok, _broadway} =
       DummyPipeline.start_link(
         test_pid: self(),
-        topic: @topic,
+        topics: [@topic],
         subscription: "named-client-sub",
         client: @client,
         name: :named_client_pipeline,
@@ -119,7 +119,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     {:ok, _broadway} =
       DummyPipeline.start_link(
         test_pid: self(),
-        topic: @topic,
+        topics: [@topic],
         subscription: "nack-sub",
         client: @client,
         handler: :nack,
@@ -150,7 +150,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     {:ok, _broadway} =
       DummyPipeline.start_link(
         test_pid: self(),
-        topic: @topic,
+        topics: [@topic],
         subscription: "dlq-sub",
         client: @client,
         handler: :nack,
@@ -204,7 +204,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     {:ok, _broadway} =
       DummyPipeline.start_link(
         test_pid: self(),
-        topic: @topic,
+        topics: [@topic],
         subscription: "permit-drain-sub",
         client: @client,
         handler: :nack,
@@ -232,7 +232,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     {:ok, _broadway} =
       DummyPipeline.start_link(
         test_pid: self(),
-        topic: @topic,
+        topics: [@topic],
         subscription: "metadata-sub",
         client: @client,
         name: :metadata_pipeline,
@@ -300,7 +300,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     {:ok, broadway} =
       DummyPipeline.start_link(
         test_pid: self(),
-        topic: @topic,
+        topics: [@topic],
         subscription: "shutdown-sub",
         client: @client,
         name: :shutdown_test_pipeline,
@@ -321,7 +321,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     {:ok, first_pipeline} =
       DummyPipeline.start_link(
         test_pid: self(),
-        topic: @topic,
+        topics: [@topic],
         subscription: subscription,
         client: @client,
         name: :failover_active_pipeline,
@@ -343,7 +343,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     {:ok, second_pipeline} =
       DummyPipeline.start_link(
         test_pid: self(),
-        topic: @topic,
+        topics: [@topic],
         subscription: subscription,
         client: @client,
         name: :failover_standby_pipeline,
@@ -364,7 +364,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     {:ok, pipeline} =
       DummyPipeline.start_link(
         test_pid: self(),
-        topic: @partitioned_topic,
+        topics: [@partitioned_topic],
         subscription: subscription,
         client: @client,
         name: :failover_partition_callback_pipeline,
@@ -586,7 +586,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
   end
 
   defp start_pipeline(name, topic, subscription, opts \\ []) do
-    defaults = [test_pid: self(), topic: topic, subscription: subscription, client: @client, name: name]
+    defaults = [test_pid: self(), topics: [topic], subscription: subscription, client: @client, name: name]
     DummyPipeline.start_link(Keyword.merge(defaults, opts))
   end
 

--- a/test/off_broadway/pulsar/producer_test.exs
+++ b/test/off_broadway/pulsar/producer_test.exs
@@ -23,13 +23,59 @@ defmodule OffBroadway.Pulsar.ProducerTest do
   describe "init/1" do
     test "raises a helpful error when the client is not running" do
       assert_raise ArgumentError, ~r/Pulsar client :no_such_client is not running/, fn ->
-        Producer.init(topic: "t", subscription: "s", client: :no_such_client)
+        Producer.init(topics: ["t"], subscription: "s", client: :no_such_client)
       end
     end
 
-    test "raises when neither :topic nor :topics is given" do
-      assert_raise ArgumentError, "either :topic or :topics is required", fn ->
+    test "raises when :topics is not given" do
+      assert_raise ArgumentError, ~r/required :topics option not found/, fn ->
         Producer.init(subscription: "s")
+      end
+    end
+
+    test "raises when :topics is empty" do
+      assert_raise ArgumentError, ~r/expected a non-empty list of topic names, got: \[\]/, fn ->
+        Producer.init(topics: [], subscription: "s")
+      end
+    end
+
+    test "raises when :topics is not a list of strings" do
+      assert_raise ArgumentError, ~r/expected a non-empty list of topic names, got: "t"/, fn ->
+        Producer.init(topics: "t", subscription: "s")
+      end
+    end
+
+    test "raises when :subscription is missing" do
+      assert_raise ArgumentError, ~r/required :subscription option not found/, fn ->
+        Producer.init(topics: ["t"])
+      end
+    end
+
+    test "raises on an option of the wrong type" do
+      assert_raise ArgumentError, ~r/invalid value for :flow_initial option/, fn ->
+        Producer.init(topics: ["t"], subscription: "s", flow_initial: "100")
+      end
+    end
+
+    test "raises on a malformed :active_state_callback" do
+      assert_raise ArgumentError, ~r/invalid value for :active_state_callback option/, fn ->
+        Producer.init(topics: ["t"], subscription: "s", active_state_callback: {SomeModule, :handle})
+      end
+    end
+
+    test "accepts an explicit nil :active_state_callback, as when it comes from application env" do
+      assert_raise ArgumentError, ~r/Pulsar client :no_such_client is not running/, fn ->
+        Producer.init(topics: ["t"], subscription: "s", client: :no_such_client, active_state_callback: nil)
+      end
+    end
+
+    test "raises on a :consumer_opts key the producer sets itself" do
+      assert_raise ArgumentError, ~r/:consumer_count cannot be set here.+concurrency: N/, fn ->
+        Producer.init(topics: ["t"], subscription: "s", consumer_opts: [consumer_count: 4])
+      end
+
+      assert_raise ArgumentError, ~r/:flow_initial cannot be set here/, fn ->
+        Producer.init(topics: ["t"], subscription: "s", consumer_opts: [flow_initial: 10])
       end
     end
 
@@ -40,7 +86,7 @@ defmodule OffBroadway.Pulsar.ProducerTest do
       })
 
       assert_raise ArgumentError, ~r/flow_threshold \(10\) must be less than flow_initial \(10\)/, fn ->
-        Producer.init(topic: "t", subscription: "s", client: :fake_client, flow_initial: 10, flow_threshold: 10)
+        Producer.init(topics: ["t"], subscription: "s", client: :fake_client, flow_initial: 10, flow_threshold: 10)
       end
     end
   end

--- a/test/support/dummy_pipeline.ex
+++ b/test/support/dummy_pipeline.ex
@@ -11,15 +11,10 @@ defmodule OffBroadwayPulsar.Test.Support.DummyPipeline do
     producer_concurrency = Keyword.get(opts, :producer_concurrency, 1)
     processor_concurrency = Keyword.get(opts, :processor_concurrency, 1)
 
-    topic_config =
-      if Keyword.has_key?(opts, :topics) do
-        [topics: Keyword.fetch!(opts, :topics)]
-      else
-        [topic: Keyword.get(opts, :topic, "persistent://public/default/test-topic")]
-      end
+    topics = Keyword.get(opts, :topics, ["persistent://public/default/test-topic"])
 
     producer_config =
-      ([subscription: subscription, consumer_opts: consumer_opts] ++ topic_config)
+      [subscription: subscription, consumer_opts: consumer_opts, topics: topics]
       |> maybe_put(opts, :client)
       |> maybe_put(opts, :flow_initial)
       |> maybe_put(opts, :flow_threshold)


### PR DESCRIPTION
## Summary

Replaces the producer's hand-rolled option handling with a `NimbleOptions` schema, and makes `:topics` the only way to name topics.

- Validates every producer option against `@opts_schema` when the stage starts, raising `ArgumentError` with the formatted message.
- Removes the `@supported_consumer_opts` whitelist and its `Keyword.take/2`. Consumer options are no longer mirrored here: pulsar-elixir 3.x validates them itself in `Pulsar.Consumer.Options`, so the only keys this producer rejects are the ones it sets.
- Removes the legacy `:topic` option in favour of `:topics`, which is now required and must be a non-empty list of strings.
- Generates the option documentation from the schema with `NimbleOptions.docs/1`, replacing a hand-maintained copy of pulsar-elixir's own option docs.

`nimble_options` was already resolved transitively through both `broadway` and `pulsar_elixir`; this only makes the dependency direct.

Validation caught a live bug: Broadway injects a `:broadway` key, carrying the pipeline name and stage index, into the producer's options. The previous `Keyword.get/3`-based code ignored it silently. It is now popped explicitly before validation.

## Breaking changes

| Before | Now |
| --- | --- |
| `topic: "t"` accepted as a single-topic shorthand | Removed; `:topics` is required and must be a non-empty list |
| Unknown producer options ignored | Rejected when the stage starts |
| Unknown `:consumer_opts` keys dropped by `Keyword.take/2` | Rejected by `Pulsar.Consumer`'s own schema |
| `:consumer_count` and `:flow_*` inside `:consumer_opts` dropped | Rejected, pointing at `producer: [concurrency: N]` and the top-level `:flow_*` options |
| A malformed `:active_state_callback` crashed the consumer at the first failover transition | Rejected by the `:mfa` type |
| An invalid `:subscription_type` passed through to the broker | Rejected by `Pulsar.Consumer`'s `{:in, [...]}` type |

All of these fail when the pipeline starts, so an affected configuration surfaces on boot rather than at the first message.

## Delegation to pulsar-elixir

Consumer options are not described here. `Pulsar.Consumer.Options` is the single schema for them and `Pulsar.Consumer.start_link/1` applies it, so this producer neither mirrors their names nor restates their defaults — a default declared in both places would pin pulsar-elixir's value as of the day it was copied. `:consumer_opts` is typed as a plain `:keyword_list` and forwarded, with the keys the producer sets itself rejected first: `:client`, `:topic`, `:subscription_name`, `:callback_module`, `:init_args`, `:name`, `:consumer_count`, `:flow_policy`, `:flow_initial`, `:flow_threshold` and `:flow_refill`.

Two checks stay outside the schema, since NimbleOptions can express neither: `:flow_threshold` must be less than `:flow_initial`, and the `Pulsar.Client` must already be running. Rejecting an empty `:topics` list needs a `{:custom, ...}` validator, because `{:list, :string}` would accept one and leave the stage running with nothing to consume.

## Verification

- `mix test` — 53 tests passing
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`
