### PR TITLE
docs: extend docs about manual flow control

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,13 +105,44 @@ lists every option with its type and default.
 
 ### Flow control
 
+Two budgets bound the pipeline, and they are not shaped the same way. Each consumer holds its
+own Pulsar permit window, bounding what the broker delivers into the producer's buffer. Demand
+is a single per-stage counter: the producer keeps one buffer and one demand tally across all
+of its consumers, and dispatches in arrival order regardless of which topic or partition a
+message came from. Messages delivered ahead of demand wait in that shared buffer.
+
 The `:flow_*` options replace the consumer's own automatic refills. Each consumer grants its
 full `:flow_initial` window as soon as it subscribes — before Broadway has asked for
 anything — and the producer grants every refill after that, sized to what Broadway has
-actually taken. Read-ahead is therefore bounded by the permit window rather than by pipeline
-demand: messages delivered ahead of demand wait in the producer's buffer. Each consumer
-keeps its own window — one per topic, and one per partition of a partitioned topic — and
-each producer stage has its own consumers, so size `:flow_initial` with that total in mind.
+actually taken. Permits are charged when messages leave the buffer for the processors, not
+when they are acknowledged, so a slow `handle_message/3` does not hold the window closed.
+Because the buffer is shared, a delivery is charged only once it reaches the head, so one
+consumer's refill can wait behind another's undispatched messages; when demand is chronically
+short, the windows drain together rather than independently.
+
+Each consumer keeps its own window — one per topic, and one per partition of a partitioned
+topic — and each producer stage has its own consumers. A refill is granted once the window
+falls to `:flow_threshold` and adds `:flow_refill` on top of what is left, so a consumer's
+window peaks at `max(flow_initial, flow_threshold + flow_refill)` and a stage's read-ahead is
+roughly that times its consumer count. The defaults make the two halves equal, at 100 permits;
+raising `:flow_refill` alone raises the ceiling well above `:flow_initial`.
+
+Size that total against the pipeline's in-flight demand, bounded above by `max_demand` ×
+processor concurrency (or `batch_size` when batching). Treat that as a ceiling rather than a
+steady figure: GenStage reissues demand in `max_demand - min_demand` increments once a stage's
+in-flight events fall to `:min_demand`, so outstanding demand oscillates between the two
+instead of sitting at the maximum. With Broadway's default `:min_demand` of half `:max_demand`,
+the average settles nearer three quarters of the ceiling — size to that order of magnitude, not
+to an exact number.
+
+A window smaller than that demand bounds ingress rate, not concurrency. Because permits are
+charged at dispatch, each refill admits another delivery while earlier messages are still being
+processed, so successive refills can fill all outstanding demand; sustained throughput is
+roughly the window divided by the refill round-trip, and processors idle only once that falls
+below what they can consume. Far above the demand, messages accumulate unacknowledged in the
+producer's buffer, costing memory and counting against the broker's
+`maxUnackedMessagesPerConsumer` limit, which stops delivery on shared subscriptions once
+crossed.
 
 ### Consumer options
 

--- a/README.md
+++ b/README.md
@@ -105,44 +105,21 @@ lists every option with its type and default.
 
 ### Flow control
 
-Two budgets bound the pipeline, and they are not shaped the same way. Each consumer holds its
-own Pulsar permit window, bounding what the broker delivers into the producer's buffer. Demand
-is a single per-stage counter: the producer keeps one buffer and one demand tally across all
-of its consumers, and dispatches in arrival order regardless of which topic or partition a
-message came from. Messages delivered ahead of demand wait in that shared buffer.
+Pulsar flow control and Broadway demand are separate budgets:
 
-The `:flow_*` options replace the consumer's own automatic refills. Each consumer grants its
-full `:flow_initial` window as soon as it subscribes — before Broadway has asked for
-anything — and the producer grants every refill after that, sized to what Broadway has
-actually taken. Permits are charged when messages leave the buffer for the processors, not
-when they are acknowledged, so a slow `handle_message/3` does not hold the window closed.
-Because the buffer is shared, a delivery is charged only once it reaches the head, so one
-consumer's refill can wait behind another's undispatched messages; when demand is chronically
-short, the windows drain together rather than independently.
+| Budget | Scope | Controls |
+| --- | --- | --- |
+| Pulsar permits | Each topic or partition consumer | Broker read-ahead into the producer buffer |
+| Broadway demand | Each producer stage | Dispatch from that buffer to processors |
 
-Each consumer keeps its own window — one per topic, and one per partition of a partitioned
-topic — and each producer stage has its own consumers. A refill is granted once the window
-falls to `:flow_threshold` and adds `:flow_refill` on top of what is left, so a consumer's
-window peaks at `max(flow_initial, flow_threshold + flow_refill)` and a stage's read-ahead is
-roughly that times its consumer count. The defaults make the two halves equal, at 100 permits;
-raising `:flow_refill` alone raises the ceiling well above `:flow_initial`.
+Permits are charged when messages are dispatched, not when they are acknowledged. The
+approximate maximum window per consumer is
+`max(flow_initial, flow_threshold + flow_refill)`; multiply it by the consumer count to
+estimate total read-ahead.
 
-Size that total against the pipeline's in-flight demand, bounded above by `max_demand` ×
-processor concurrency (or `batch_size` when batching). Treat that as a ceiling rather than a
-steady figure: GenStage reissues demand in `max_demand - min_demand` increments once a stage's
-in-flight events fall to `:min_demand`, so outstanding demand oscillates between the two
-instead of sitting at the maximum. With Broadway's default `:min_demand` of half `:max_demand`,
-the average settles nearer three quarters of the ceiling — size to that order of magnitude, not
-to an exact number.
-
-A window smaller than that demand bounds ingress rate, not concurrency. Because permits are
-charged at dispatch, each refill admits another delivery while earlier messages are still being
-processed, so successive refills can fill all outstanding demand; sustained throughput is
-roughly the window divided by the refill round-trip, and processors idle only once that falls
-below what they can consume. Far above the demand, messages accumulate unacknowledged in the
-producer's buffer, costing memory and counting against the broker's
-`maxUnackedMessagesPerConsumer` limit, which stops delivery on shared subscriptions once
-crossed.
+Larger windows reduce refill overhead but increase buffered and unacknowledged messages.
+Smaller windows may limit throughput. See the producer documentation above for the detailed
+refill semantics.
 
 ### Consumer options
 

--- a/README.md
+++ b/README.md
@@ -105,14 +105,8 @@ lists every option with its type and default.
 
 ### Flow control
 
-Pulsar flow control and Broadway demand are separate budgets:
-
-| Budget | Scope | Controls |
-| --- | --- | --- |
-| Pulsar permits | Each topic or partition consumer | Broker read-ahead into the producer buffer |
-| Broadway demand | Each producer stage | Dispatch from that buffer to processors |
-
-Permits are charged when messages are dispatched, not when they are acknowledged. The
+`:flow_initial` permits are granted when each topic or partition consumer becomes ready. When
+the remaining permits reach `:flow_threshold`, the producer adds `:flow_refill` permits. The
 approximate maximum window per consumer is
 `max(flow_initial, flow_threshold + flow_refill)`; multiply it by the consumer count to
 estimate total read-ahead.
@@ -143,7 +137,22 @@ or fencing mechanism. The
 [producer documentation](https://hexdocs.pm/off_broadway_pulsar/OffBroadway.Pulsar.Producer.html#start_link/1)
 has the complete callback contract.
 
-## Architecture and failure propagation
+## Architecture
+
+### Back-pressure and buffering
+
+Pulsar flow control and Broadway demand are separate budgets:
+
+| Budget | Scope | Controls |
+| --- | --- | --- |
+| Pulsar permits | Each topic or partition consumer | Broker read-ahead into the producer buffer |
+| Broadway demand | Each producer stage | Dispatch from that buffer to processors |
+
+Each producer stage shares one Broadway demand counter and one message buffer across its
+consumers. Messages delivered ahead of demand wait in that buffer. Permits are charged when
+messages are dispatched, not when they are acknowledged.
+
+### Ownership and failure propagation
 
 Broadway and pulsar-elixir have different lifecycle boundaries. The `Pulsar.Client` owns
 shared connection infrastructure; each Broadway producer stage owns the consumers that feed

--- a/lib/off_broadway/pulsar/producer.ex
+++ b/lib/off_broadway/pulsar/producer.ex
@@ -125,17 +125,47 @@ defmodule OffBroadway.Pulsar.Producer do
 
   ## Flow Control
 
+  Two budgets bound the pipeline, and they are not shaped the same way. Each consumer holds its
+  own permit window, bounding what the broker delivers into the producer's buffer. Demand is a
+  single per-stage counter: the stage keeps one buffer and one demand tally across all of its
+  consumers, and dispatches in arrival order regardless of which topic or partition a delivery
+  came from. Deliveries that arrive ahead of demand wait in that shared buffer.
+
   The `:flow_*` options replace the consumer's own automatic refills: the producer sets the consumer's
   `:flow_policy` to report what each delivery cost and grants the refills itself, sized to
   what Broadway has taken. Each worker still grants its full `:flow_initial` window when it
-  subscribes, independently of pipeline demand, so read-ahead is bounded by the permit window
-  rather than by demand; deliveries that arrive ahead of demand wait in the producer's buffer.
-  Processor demand is served from the window already granted, rather than triggering a flow
-  request of its own.
+  subscribes, independently of pipeline demand. Processor demand is served from the window
+  already granted, rather than triggering a flow request of its own. Permits are charged when
+  messages leave the buffer for the processors, not when they are acknowledged, so a slow
+  `c:Broadway.handle_message/3` does not hold the window closed. Because the buffer is shared,
+  a delivery is charged only once it reaches the head, so one consumer's refill can wait behind
+  another's undispatched messages; when demand is chronically short, the windows drain together
+  rather than independently.
 
   Each consumer keeps its own window — one per topic, and one per partition of a
   partitioned topic. With `producer: [concurrency: N]`, each producer has its own
-  consumers, and so its own windows.
+  consumers, and so its own windows. A refill is granted once the window falls to
+  `:flow_threshold` and adds `:flow_refill` on top of what is left, so a consumer's window peaks
+  at `max(flow_initial, flow_threshold + flow_refill)` and a stage's read-ahead is roughly that
+  times its consumer count. The defaults make the two halves equal, at 100 permits; raising
+  `:flow_refill` alone raises the ceiling well above `:flow_initial`.
+
+  Size that total against the pipeline's in-flight demand, bounded above by `max_demand` ×
+  processor concurrency (or `batch_size` when batching). Treat that as a ceiling rather than a
+  steady figure: GenStage reissues demand in `max_demand - min_demand` increments once a stage's
+  in-flight events fall to `:min_demand`, so outstanding demand oscillates between the two
+  instead of sitting at the maximum. With Broadway's default `:min_demand` of half `:max_demand`,
+  the average settles nearer three quarters of the ceiling — size to that order of magnitude, not
+  to an exact number.
+
+  A window smaller than that demand bounds ingress rate, not concurrency. Because permits are
+  charged at dispatch, each refill admits another delivery while earlier messages are still being
+  processed, so successive refills can fill all outstanding demand; sustained throughput is
+  roughly the window divided by the refill round-trip, and processors idle only once that falls
+  below what they can consume. Far above the demand, messages accumulate unacknowledged in the
+  producer's buffer, costing memory and counting against the broker's
+  `maxUnackedMessagesPerConsumer` limit, which stops delivery on shared subscriptions once
+  crossed.
 
   ## Consumer ownership
 

--- a/lib/off_broadway/pulsar/producer.ex
+++ b/lib/off_broadway/pulsar/producer.ex
@@ -125,47 +125,19 @@ defmodule OffBroadway.Pulsar.Producer do
 
   ## Flow Control
 
-  Two budgets bound the pipeline, and they are not shaped the same way. Each consumer holds its
-  own permit window, bounding what the broker delivers into the producer's buffer. Demand is a
-  single per-stage counter: the stage keeps one buffer and one demand tally across all of its
-  consumers, and dispatches in arrival order regardless of which topic or partition a delivery
-  came from. Deliveries that arrive ahead of demand wait in that shared buffer.
+  Each topic or partition consumer has its own Pulsar permit window. Broadway demand and the
+  message buffer are shared by all consumers owned by one producer stage, so deliveries that
+  arrive ahead of demand wait in that buffer.
 
-  The `:flow_*` options replace the consumer's own automatic refills: the producer sets the consumer's
-  `:flow_policy` to report what each delivery cost and grants the refills itself, sized to
-  what Broadway has taken. Each worker still grants its full `:flow_initial` window when it
-  subscribes, independently of pipeline demand. Processor demand is served from the window
-  already granted, rather than triggering a flow request of its own. Permits are charged when
-  messages leave the buffer for the processors, not when they are acknowledged, so a slow
-  `c:Broadway.handle_message/3` does not hold the window closed. Because the buffer is shared,
-  a delivery is charged only once it reaches the head, so one consumer's refill can wait behind
-  another's undispatched messages; when demand is chronically short, the windows drain together
-  rather than independently.
+  Each consumer grants `:flow_initial` permits when it subscribes. Permits are charged when
+  messages leave the buffer for the processors, not when they are acknowledged. When the
+  remaining permits reach `:flow_threshold`, the producer grants another `:flow_refill` permits.
 
-  Each consumer keeps its own window — one per topic, and one per partition of a
-  partitioned topic. With `producer: [concurrency: N]`, each producer has its own
-  consumers, and so its own windows. A refill is granted once the window falls to
-  `:flow_threshold` and adds `:flow_refill` on top of what is left, so a consumer's window peaks
-  at `max(flow_initial, flow_threshold + flow_refill)` and a stage's read-ahead is roughly that
-  times its consumer count. The defaults make the two halves equal, at 100 permits; raising
-  `:flow_refill` alone raises the ceiling well above `:flow_initial`.
-
-  Size that total against the pipeline's in-flight demand, bounded above by `max_demand` ×
-  processor concurrency (or `batch_size` when batching). Treat that as a ceiling rather than a
-  steady figure: GenStage reissues demand in `max_demand - min_demand` increments once a stage's
-  in-flight events fall to `:min_demand`, so outstanding demand oscillates between the two
-  instead of sitting at the maximum. With Broadway's default `:min_demand` of half `:max_demand`,
-  the average settles nearer three quarters of the ceiling — size to that order of magnitude, not
-  to an exact number.
-
-  A window smaller than that demand bounds ingress rate, not concurrency. Because permits are
-  charged at dispatch, each refill admits another delivery while earlier messages are still being
-  processed, so successive refills can fill all outstanding demand; sustained throughput is
-  roughly the window divided by the refill round-trip, and processors idle only once that falls
-  below what they can consume. Far above the demand, messages accumulate unacknowledged in the
-  producer's buffer, costing memory and counting against the broker's
-  `maxUnackedMessagesPerConsumer` limit, which stops delivery on shared subscriptions once
-  crossed.
+  The approximate maximum window per consumer is
+  `max(flow_initial, flow_threshold + flow_refill)`. Account for every topic or partition
+  consumer and every producer stage when estimating total read-ahead. Larger windows reduce
+  refill overhead but increase buffered and unacknowledged messages; smaller windows may limit
+  throughput.
 
   ## Consumer ownership
 


### PR DESCRIPTION
## Summary

Clarifies how Pulsar permit windows interact with Broadway demand and documents the effective per-consumer window.

Keeps the README concise while retaining the refill semantics and tuning guidance in the producer documentation.
