### PR TITLE
fix: survive the loss of a consumer worker

### DIFF
--- a/lib/off_broadway/pulsar/acknowledger.ex
+++ b/lib/off_broadway/pulsar/acknowledger.ex
@@ -2,20 +2,41 @@ defmodule OffBroadway.Pulsar.Acknowledger do
   @moduledoc false
   @behaviour Broadway.Acknowledger
 
+  require Logger
+
   @impl Broadway.Acknowledger
   def ack(%{consumer: consumer}, successful, failed) do
-    ack_ids =
-      Enum.flat_map(successful, fn %{acknowledger: {_, _, message_id}} ->
-        List.wrap(message_id)
-      end)
+    acknowledge(consumer, :ack, message_ids(successful))
+    acknowledge(consumer, :nack, message_ids(failed))
 
-    :ok = Pulsar.Consumer.ack(consumer, ack_ids)
+    :ok
+  end
 
-    nack_ids =
-      Enum.flat_map(failed, fn %{acknowledger: {_, _, message_id}} ->
-        List.wrap(message_id)
-      end)
+  defp message_ids(messages) do
+    Enum.flat_map(messages, fn %{acknowledger: {_, _, message_id}} ->
+      List.wrap(message_id)
+    end)
+  end
 
-    :ok = Pulsar.Consumer.nack(consumer, nack_ids)
+  defp acknowledge(_consumer, _operation, []), do: :ok
+
+  # Broadway acknowledges every worker of a batch from one process and lets an exit abort the
+  # ones it has not reached, so a worker that has already been replaced would take its live
+  # siblings' acknowledgements with it. Its own messages need none: the broker returns what the
+  # old worker left unacknowledged to the replacement.
+  defp acknowledge(consumer, operation, message_ids) do
+    case apply(Pulsar.Consumer, operation, [consumer, message_ids]) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Logger.warning("Pulsar #{operation} of #{length(message_ids)} message(s) failed: #{inspect(reason)}")
+    end
+  catch
+    :exit, reason ->
+      Logger.warning(
+        "Dropping #{operation} of #{length(message_ids)} message(s): " <>
+          "consumer #{inspect(consumer)} is gone (#{inspect(reason)})"
+      )
   end
 end

--- a/lib/off_broadway/pulsar/producer.ex
+++ b/lib/off_broadway/pulsar/producer.ex
@@ -151,8 +151,13 @@ defmodule OffBroadway.Pulsar.Producer do
   owns them by pid, so replacing the client's consumer Registry does not affect them, although
   their former names no longer resolve. Stop the Broadway pipeline to stop them permanently.
 
-  A terminal subscription error can leave a root alive with a stopped group. The stage
-  detects that state and restarts instead of remaining healthy with nothing to consume.
+  A terminal subscription error can leave a root alive with a stopped group, and a worker that
+  exits normally is not replaced, leaving a group alive with nothing consuming. The stage
+  detects both and restarts instead of remaining healthy with nothing to consume.
+
+  A worker that is replaced is not one of those cases. The replacement registers under a new
+  pid and the broker returns whatever the old worker left unacknowledged to it, so messages
+  still in the pipeline under the old pid are dropped when they come to be acknowledged.
 
   ## Message Metadata
 
@@ -365,7 +370,7 @@ defmodule OffBroadway.Pulsar.Producer do
         {:noreply, [], state}
 
       {:stopped, topic} ->
-        Logger.error("Consumer for #{topic} has a stopped group and no worker left; stopping")
+        Logger.error("Consumer for #{topic} has a group with no worker left; stopping")
 
         {:stop, {:shutdown, {:consumer_stopped, topic}}, state}
     end
@@ -491,7 +496,8 @@ defmodule OffBroadway.Pulsar.Producer do
 
   defp schedule_health_check, do: Process.send_after(self(), :check_consumers, @health_check_interval_ms)
 
-  # Terminal subscription errors can stop a group without stopping its root.
+  # Terminal subscription errors can stop a group without stopping its root, and a worker that
+  # exits normally is not replaced, so a group can also be up with nothing left consuming.
   defp check_consumers(state) do
     Enum.reduce_while(state.consumer_roots, :ok, fn {root, {topic, _monitor_ref}}, :ok ->
       if stopped_group?(root), do: {:halt, {:stopped, topic}}, else: {:cont, :ok}
@@ -502,13 +508,25 @@ defmodule OffBroadway.Pulsar.Producer do
     root
     |> Supervisor.which_children()
     |> Enum.any?(fn
-      {{:topic, :non_partitioned}, :undefined, _type, _modules} -> true
-      {{:partition, _index}, :undefined, _type, _modules} -> true
+      {{:topic, :non_partitioned}, group, :supervisor, _modules} -> group_stopped?(group)
+      {{:partition, _index}, group, :supervisor, _modules} -> group_stopped?(group)
       _child -> false
     end)
   catch
     # Root exits are reported by its monitor.
     :exit, _reason -> false
+  end
+
+  defp group_stopped?(:undefined), do: true
+  defp group_stopped?(group) when is_pid(group), do: no_live_worker?(group)
+  defp group_stopped?(_restarting), do: false
+
+  # A group the client has not populated yet reports no children at all.
+  defp no_live_worker?(group) do
+    case Supervisor.which_children(group) do
+      [] -> false
+      workers -> Enum.all?(workers, &match?({_id, :undefined, _type, _modules}, &1))
+    end
   end
 
   defp start_consumer!(opts) do

--- a/test/integration/producer_test.exs
+++ b/test/integration/producer_test.exs
@@ -13,9 +13,11 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
   @partitioned_topic "persistent://public/default/broadway-failover-partitioned"
   @ownership_topic "persistent://public/default/broadway-consumer-ownership"
   @exclusive_topic "persistent://public/default/broadway-exclusive-ownership"
+  @restart_topic "persistent://public/default/broadway-worker-restart"
   @partition_count 2
   @message_count 100
   @multi_topic_message_count 20
+  @restart_message_count 200
 
   setup_all do
     alias OffBroadwayPulsar.Test.Support.System
@@ -26,6 +28,7 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
     :ok = System.create_partitioned_topic(@partitioned_topic, @partition_count)
     :ok = System.create_topic(@ownership_topic)
     :ok = System.create_topic(@exclusive_topic)
+    :ok = System.create_topic(@restart_topic)
 
     {:ok, _client_pid} =
       Pulsar.Client.start_link(
@@ -583,6 +586,77 @@ defmodule OffBroadwayPulsar.Integration.ProducerTest do
 
       assert :ok = Broadway.stop(broadway)
     end
+
+    @tag :capture_log
+    test "a worker killed mid-drain leaves no message unconsumed" do
+      subscription = "worker-restart-sub"
+      producer = start_ready_producer(:worker_restart_producer, @restart_topic)
+
+      {:ok, broadway} =
+        start_pipeline(:worker_restart_pipeline, @restart_topic, subscription, handler: &slow_handler/2)
+
+      assert [root] = consumer_roots(subscription)
+      assert :ok = Pulsar.Consumer.await_ready(root)
+      assert [worker] = consumer_workers(root)
+
+      payloads = Enum.map(1..@restart_message_count, &"restart-#{&1}")
+      for payload <- payloads, do: {:ok, _msg_id} = Pulsar.Producer.send(producer, payload)
+
+      # Kill with the drain in flight, so the pipeline holds messages that name a worker it
+      # can no longer acknowledge against.
+      seen = collect_payloads(MapSet.new(), 10, 30_000)
+      assert MapSet.size(seen) >= 10
+      Process.exit(worker, :kill)
+
+      replacement = wait_until(fn -> Enum.find(consumer_workers(root), &(&1 != worker)) end, 20_000)
+      assert is_pid(replacement)
+
+      seen = collect_payloads(seen, @restart_message_count, 60_000)
+      assert MapSet.to_list(MapSet.difference(MapSet.new(payloads), seen)) == []
+
+      assert :ok = Broadway.stop(broadway)
+    end
+  end
+
+  defp slow_handler(message, context) do
+    # Paces the drain so the kill lands while messages are still in flight.
+    Process.sleep(5)
+    send(context.test_pid, {:message_handled, message.data})
+    message
+  end
+
+  defp collect_payloads(seen, target, timeout) do
+    do_collect_payloads(seen, target, System.monotonic_time(:millisecond) + timeout)
+  end
+
+  defp do_collect_payloads(seen, target, deadline) do
+    remaining = deadline - System.monotonic_time(:millisecond)
+
+    if MapSet.size(seen) >= target or remaining <= 0 do
+      seen
+    else
+      receive do
+        {:message_handled, payload} -> do_collect_payloads(MapSet.put(seen, payload), target, deadline)
+      after
+        remaining -> seen
+      end
+    end
+  end
+
+  defp consumer_workers(root) do
+    root
+    |> Supervisor.which_children()
+    |> Enum.flat_map(fn
+      {_id, group, :supervisor, _modules} when is_pid(group) -> group_workers(group)
+      _child -> []
+    end)
+  end
+
+  defp group_workers(group) do
+    Enum.flat_map(Supervisor.which_children(group), fn
+      {_id, worker, _type, _modules} when is_pid(worker) -> [worker]
+      _child -> []
+    end)
   end
 
   defp start_pipeline(name, topic, subscription, opts \\ []) do

--- a/test/off_broadway/pulsar/acknowledger_test.exs
+++ b/test/off_broadway/pulsar/acknowledger_test.exs
@@ -1,0 +1,79 @@
+defmodule OffBroadway.Pulsar.AcknowledgerTest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureLog
+
+  alias OffBroadway.Pulsar.Acknowledger
+  alias OffBroadwayPulsar.Test.Support.StubConsumer
+
+  defp message(consumer, id) do
+    %Broadway.Message{
+      data: "payload",
+      acknowledger: {Acknowledger, %{consumer: consumer}, %{ledgerId: 1, entryId: id}}
+    }
+  end
+
+  defp dead_consumer do
+    {:ok, consumer} = StubConsumer.start_link(self())
+    Process.unlink(consumer)
+    ref = Process.monitor(consumer)
+    Process.exit(consumer, :kill)
+    assert_receive {:DOWN, ^ref, :process, ^consumer, :killed}
+
+    consumer
+  end
+
+  test "acknowledges successful and failed messages against the delivering worker" do
+    {:ok, consumer} = start_supervised({StubConsumer, self()})
+
+    assert :ok = Acknowledger.ack(%{consumer: consumer}, [message(consumer, 1)], [message(consumer, 2)])
+
+    assert_receive {:ack, [%{entryId: 1}]}
+    assert_receive {:nack, [%{entryId: 2}]}
+  end
+
+  test "does not call the worker when there is nothing to acknowledge" do
+    {:ok, consumer} = start_supervised({StubConsumer, self()})
+
+    assert :ok = Acknowledger.ack(%{consumer: consumer}, [message(consumer, 1)], [])
+
+    assert_receive {:ack, [%{entryId: 1}]}
+    refute_receive {:nack, _ids}
+  end
+
+  test "drops the acknowledgements of a worker that has been replaced" do
+    consumer = dead_consumer()
+
+    log =
+      capture_log(fn ->
+        assert :ok = Acknowledger.ack(%{consumer: consumer}, [message(consumer, 1)], [message(consumer, 2)])
+      end)
+
+    assert log =~ "Dropping ack of 1 message(s)"
+    assert log =~ "Dropping nack of 1 message(s)"
+  end
+
+  test "a replaced worker does not abort the acknowledgements owed to its live siblings" do
+    # Broadway acknowledges one worker at a time, in key order, and stops at the first exit;
+    # the older pid sorts first, so the dead worker is the one reached first.
+    dead = dead_consumer()
+    {:ok, live} = start_supervised({StubConsumer, self()})
+
+    capture_log(fn ->
+      Broadway.Acknowledger.ack_messages([message(dead, 1), message(live, 2)], [])
+    end)
+
+    assert_receive {:ack, [%{entryId: 2}]}
+  end
+
+  test "logs an error reply instead of failing the batch" do
+    {:ok, consumer} = start_supervised({StubConsumer, {self(), {:error, :not_connected}}})
+
+    log =
+      capture_log(fn ->
+        assert :ok = Acknowledger.ack(%{consumer: consumer}, [message(consumer, 1)], [])
+      end)
+
+    assert log =~ "Pulsar ack of 1 message(s) failed: :not_connected"
+  end
+end

--- a/test/off_broadway/pulsar/producer_test.exs
+++ b/test/off_broadway/pulsar/producer_test.exs
@@ -260,25 +260,52 @@ defmodule OffBroadway.Pulsar.ProducerTest do
     test "the health check stops when a consumer has a group the client gave up on" do
       %{root: root, state: state} = healthy_consumer()
 
-      [{_id, group, _type, _modules}] = Supervisor.which_children(root)
-      :ok = Agent.stop(group)
+      :ok = Supervisor.stop(group(root))
 
       assert {:stop, {:shutdown, {:consumer_stopped, "topic"}}, _state} =
                Producer.handle_info(:check_consumers, state)
     end
+
+    test "the health check stops when a group is up but its last worker was not replaced" do
+      %{root: root, state: state} = healthy_consumer()
+
+      :ok = Agent.stop(worker(root))
+
+      assert Process.alive?(group(root))
+
+      assert {:stop, {:shutdown, {:consumer_stopped, "topic"}}, _state} =
+               Producer.handle_info(:check_consumers, state)
+    end
+
+    test "the health check leaves a group alone while one of its workers is still up" do
+      %{root: root, state: state} = healthy_consumer(worker_count: 2)
+
+      [{_id, stopped, _type, _modules} | _kept] = Supervisor.which_children(group(root))
+      :ok = Agent.stop(stopped)
+
+      assert {:noreply, [], _state} = Producer.handle_info(:check_consumers, state)
+    end
   end
 
-  defp healthy_consumer do
-    root = start_supervised!(consumer_root_spec())
+  defp healthy_consumer(opts \\ []) do
+    root = start_supervised!(consumer_root_spec(Keyword.get(opts, :worker_count, 1)))
     monitor_ref = Process.monitor(root)
 
     %{root: root, state: %{state() | consumer_roots: %{root => {"topic", monitor_ref}}}}
   end
 
-  defp consumer_root_spec do
+  # Mirrors the shape the stage inspects: a root of per-topic groups, each of them a
+  # supervisor of workers.
+  defp consumer_root_spec(worker_count) do
+    workers =
+      for index <- 1..worker_count do
+        %{id: {:worker, index}, start: {Agent, :start_link, [fn -> :ok end]}, restart: :transient}
+      end
+
     group = %{
       id: {:topic, :non_partitioned},
-      start: {Agent, :start_link, [fn -> :ok end]},
+      start: {Supervisor, :start_link, [workers, [strategy: :one_for_one]]},
+      type: :supervisor,
       restart: :transient
     }
 
@@ -287,6 +314,16 @@ defmodule OffBroadway.Pulsar.ProducerTest do
       start: {Supervisor, :start_link, [[group], [strategy: :one_for_one]]},
       type: :supervisor
     }
+  end
+
+  defp group(root) do
+    [{_id, group, :supervisor, _modules}] = Supervisor.which_children(root)
+    group
+  end
+
+  defp worker(root) do
+    [{_id, worker, _type, _modules}] = Supervisor.which_children(group(root))
+    worker
   end
 
   defp state do

--- a/test/support/stub_consumer.ex
+++ b/test/support/stub_consumer.ex
@@ -1,17 +1,23 @@
 defmodule OffBroadwayPulsar.Test.Support.StubConsumer do
   @moduledoc false
-  # Observes flow refills without a broker. Pulsar.Consumer.send_flow/3 reads
-  # :proc_lib.initial_call/1, so a plain GenServer reads as a worker and is called directly.
+  # Observes flow refills and acknowledgements without a broker. Pulsar.Consumer reaches a
+  # worker with a GenServer.call, so a plain GenServer can answer for one.
   use GenServer
 
-  def start_link(test_pid), do: GenServer.start_link(__MODULE__, test_pid)
+  def start_link({test_pid, reply}), do: GenServer.start_link(__MODULE__, {test_pid, reply})
+  def start_link(test_pid) when is_pid(test_pid), do: start_link({test_pid, :ok})
 
   @impl true
-  def init(test_pid), do: {:ok, test_pid}
+  def init(state), do: {:ok, state}
 
   @impl true
-  def handle_call({:send_flow, permits}, _from, test_pid) do
+  def handle_call({:send_flow, permits}, _from, {test_pid, _reply} = state) do
     send(test_pid, {:send_flow, permits})
-    {:reply, :ok, test_pid}
+    {:reply, :ok, state}
+  end
+
+  def handle_call({operation, message_ids}, _from, {test_pid, reply} = state) when operation in [:ack, :nack] do
+    send(test_pid, {operation, message_ids})
+    {:reply, reply, state}
   end
 end


### PR DESCRIPTION
## Summary

Stops a replaced Pulsar consumer worker from taking unrelated work down with it.

- Guards the acknowledger's `Pulsar.Consumer.ack/2` and `nack/2`, so a worker that has already been replaced is logged and dropped instead of exiting the acknowledging stage.
- Handles a non-`:ok` reply from either, which raised a `MatchError` with the same effect.
- Extends the stage health check to a group that is still up but has lost every worker, descending one level further into pulsar-elixir's private child IDs than the check added in #81.

Broadway acknowledges a batch's workers one at a time and stops at the first exit, so one replaced worker took with it the acknowledgements owed to every live worker it had not yet reached — messages that then waited for redelivery despite having been processed. Worker replacement is routine: it is how pulsar-elixir responds to a broker disconnect or a broker-initiated close.

Not a 2.0 regression. `v1.5.1` had the identical `:ok = Pulsar.ack(consumer, ack_ids)` and the same per-pid ack ref, and pulsar_elixir 2.11.1 reached the same unguarded `GenServer.call` (`consumer.ex:286-287`); 1.x had no health check at all. The 3.x reshuffle moved the call site, it did not create the behaviour — settling the open question in #80's notes.

Fixes #80.

## Behaviour

| Event | Before | After |
| --- | --- | --- |
| A replaced worker's messages reach the acknowledger | Exit; every worker not yet reached in that batch goes unacknowledged | Logged and dropped; the others are acknowledged |
| `ack/2` or `nack/2` replies `{:error, _}` | `MatchError`, aborting the batch the same way | Logged |
| A group is up but its last worker was not replaced | Undetected; the stage stays subscribed with nothing consuming | The stage stops so Broadway rebuilds it |

The exit also leaked. `Broadway.Acknowledger` stages a batch's messages in the process dictionary and clears a key only when its acknowledger is called (`acknowledger.ex:65-85`), so aborting the loop left entries behind. A live worker's were flushed on its next batch, but a dead pid never appears in another batch, so every worker replacement leaked one batch's worth of messages into the stage for the rest of its life.

Nothing is lost by dropping an acknowledgement: the message stays in the backlog, and the broker returns a disconnected consumer's unacknowledged messages to the subscription, so what is dropped duplicates what the replacement is already receiving. This assumes a durable subscription, which is the default.

## Testing

- `acknowledger_test.exs` (new) — "a replaced worker does not abort the acknowledgements owed to its live siblings" drives `Broadway.Acknowledger.ack_messages/2` with one dead and one live worker. Against the pre-fix acknowledger, 4 of its 5 tests fail.
- `producer_test.exs` — two health-check cases; the fixture now models the real root → group → workers shape.
- `integration/producer_test.exs` — kills a worker mid-drain of 200 messages and asserts every payload arrives. Covers at-least-once, not the sibling abort, which needs more than one worker in a batch.

## Verification

- `mix test` — 62 tests passing
- `mix format --check-formatted`
- `mix credo --strict`
- `mix dialyzer`
