### PR TITLE
Prepare for 2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,8 @@ producer: [
 to attach to, the `:flow_*` options tune read-ahead, `:active_state_callback` observes
 failover transitions, and `:consumer_opts` is forwarded to `Pulsar.Consumer`.
 
-Options are validated when the stage starts, so a misconfigured pipeline fails at boot rather
-than at the first message. The
+Options are validated before any stage starts, so `Broadway.start_link/2` itself raises on a
+misconfigured pipeline rather than failing at the first message. The
 [producer documentation](https://hexdocs.pm/off_broadway_pulsar/OffBroadway.Pulsar.Producer.html#start_link/1)
 lists every option with its type and default.
 
@@ -122,8 +122,8 @@ refill semantics.
 
 `:consumer_opts` is forwarded to every consumer the stage starts.
 [`Pulsar.Consumer`](https://hexdocs.pm/pulsar_elixir/Pulsar.Consumer.html) documents and
-validates the keys it accepts, so they are deliberately not mirrored here. Setting the option
-replaces the default rather than merging into it.
+validates the keys it accepts, and applies its own defaults to whatever is left out, so they
+are deliberately not mirrored here.
 
 The keys the producer sets for itself — the topic, subscription, callback module, consumer
 count and flow settings — are rejected, each naming the option that does work instead: use

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ def deps do
 end
 ```
 
+Upgrading from 1.x? See [Upgrading to 2.0](docs/upgrading_to_2.0.md) — 2.0 changes how the
+connection is configured, renames the subscription type atoms and reshapes message metadata.
+
 ## Quick Start
 
 Supervise a `Pulsar.Client` alongside your pipeline — the producer attaches its consumers

--- a/docs/upgrading_to_2.0.md
+++ b/docs/upgrading_to_2.0.md
@@ -1,9 +1,9 @@
 # Upgrading to 2.0
 
 2.0 moves to [pulsar-elixir](https://github.com/efcasado/pulsar-elixir/) 3.x and reworks how
-the producer is configured and how it owns its consumers. Every change below fails loudly at
-boot rather than silently at the first message, so a pipeline that starts is a pipeline that
-was migrated.
+the producer is configured and how it owns its consumers. The configuration changes are
+rejected at boot, so a pipeline that starts is configured correctly. The metadata change is
+not: reading a key that moved raises on the first message instead.
 
 Bump the dependency:
 
@@ -236,11 +236,16 @@ the messages that actually failed:
 consumer_opts: [subscription_type: :shared, batch_index_ack_enabled: true]
 ```
 
-It requires `acknowledgmentAtBatchIndexLevelEnabled=true` on the broker — Pulsar's shipped
-`broker.conf` enables it, `standalone.conf` does not — and costs one acknowledgement command
-per message rather than one per entry. Nothing in the protocol reports the broker setting, so
-enabling it against a broker that ignores it will acknowledge whole entries and lose the
-messages batched alongside an acked one. Verify the broker first.
+It requires `acknowledgmentAtBatchIndexLevelEnabled=true` on the broker, which is the default
+on Pulsar 4.2 — `broker.conf` sets it explicitly and a standalone broker inherits it, so a
+cluster that has not overridden it already honours the setting. Check yours with
+`bin/pulsar-admin brokers get-all-dynamic-config`, since nothing in the protocol reports it:
+against a broker with it disabled, an ack acknowledges the whole entry and loses the messages
+batched alongside it. It also costs one acknowledgement command per message rather than one
+per entry.
+
+Nacked messages come back only when `:redelivery_interval` is also set, so the two options go
+together if you want a failed message retried rather than merely narrowed.
 
 ## Complete example
 

--- a/docs/upgrading_to_2.0.md
+++ b/docs/upgrading_to_2.0.md
@@ -1,0 +1,312 @@
+# Upgrading to 2.0
+
+2.0 moves to [pulsar-elixir](https://github.com/efcasado/pulsar-elixir/) 3.x and reworks how
+the producer is configured and how it owns its consumers. Every change below fails loudly at
+boot rather than silently at the first message, so a pipeline that starts is a pipeline that
+was migrated.
+
+Bump the dependency:
+
+```elixir
+{:off_broadway_pulsar, "~> 2.0"}
+```
+
+## At a glance
+
+| 1.x | 2.0 | Where |
+| --- | --- | --- |
+| `:host` + `:conn_opts` on the producer | Supervise `Pulsar.Client` yourself | [Connections](#connections) |
+| `{Pulsar, host: ...}` in your tree | `{Pulsar.Client, host: ...}` | [Connections](#connections) |
+| `topic: "my-topic"` | `topics: ["my-topic"]` | [Topics](#topics) |
+| `subscription_type: :Shared` | `subscription_type: :shared` | [Subscription types](#subscription-types) |
+| Unknown `:consumer_opts` keys ignored | Unknown and reserved keys raise | [Consumer options](#consumer-options) |
+| `metadata.command`, `.metadata`, … | Normalized fields, raw under `:raw` | [Message metadata](#message-metadata) |
+
+## Connections
+
+The producer no longer starts or owns a connection. `:host` and `:conn_opts` are gone; the
+client is yours to supervise, so the connection outlives any one producer stage and is shared
+by all of them.
+
+If you passed `:host` to the producer:
+
+```elixir
+# 1.x
+producer: [
+  module: {OffBroadway.Pulsar.Producer,
+    host: "pulsar://localhost:6650",
+    conn_opts: [socket_opts: [verify: :verify_none]],
+    topic: "my-topic",
+    subscription: "my-subscription"
+  }
+]
+
+# 2.0
+children = [
+  {Pulsar.Client, host: "pulsar://localhost:6650", socket_opts: [verify: :verify_none]},
+  MyApp.PulsarPipeline
+]
+
+producer: [
+  module: {OffBroadway.Pulsar.Producer,
+    topics: ["my-topic"],
+    subscription: "my-subscription"
+  }
+]
+```
+
+`:conn_opts` keys move up to `Pulsar.Client` itself — there is no nested option group any more.
+
+If you were already running a global connection, the module name changed:
+
+```elixir
+# 1.x
+children = [{Pulsar, host: "pulsar://localhost:6650"}, MyApp.PulsarPipeline]
+
+# 2.0
+children = [{Pulsar.Client, host: "pulsar://localhost:6650"}, MyApp.PulsarPipeline]
+```
+
+`Pulsar.Client` registers as `:default` when unnamed, which is also the producer's default
+`:client`, so an unnamed client needs no `:client` option. Name it to run more than one:
+
+```elixir
+children = [
+  {Pulsar.Client, name: :analytics, host: "pulsar://analytics:6650"},
+  MyApp.AnalyticsPipeline
+]
+
+producer: [
+  module: {OffBroadway.Pulsar.Producer,
+    client: :analytics,
+    topics: ["my-topic"],
+    subscription: "my-subscription"
+  }
+]
+```
+
+A producer whose client is not running raises at boot with the supervision snippet it wants,
+rather than failing to consume.
+
+## Topics
+
+`:topic` is gone. Use `:topics`, always a non-empty list:
+
+```elixir
+# 1.x
+topic: "my-topic"
+
+# 2.0
+topics: ["my-topic"]
+```
+
+An empty list is rejected — it would leave a stage running with nothing to consume.
+
+## Subscription types
+
+pulsar-elixir 3.x renamed the subscription type atoms to lowercase. This is the change most
+likely to bite, because 1.x silently discarded a `:consumer_opts` key it did not recognise but
+happily accepted a wrongly-cased value:
+
+| 1.x | 2.0 |
+| --- | --- |
+| `:Exclusive` | `:exclusive` |
+| `:Shared` | `:shared` |
+| `:Failover` | `:failover` |
+| `:Key_Shared` | `:key_shared` |
+
+```elixir
+# 1.x
+consumer_opts: [subscription_type: :Failover]
+
+# 2.0
+consumer_opts: [subscription_type: :failover]
+```
+
+`:shared` remains the default. Other option values — `:initial_position`, `:start_message_id`,
+`:dead_letter_policy` and the rest — keep the shapes they had.
+
+## Consumer options
+
+In 1.x, `:consumer_opts` was filtered through an allowlist with `Keyword.take/2`: anything the
+producer did not recognise was dropped without a word, so `subsciption_type: :Failover` gave
+you a Shared subscription in production. In 2.0 the keys are validated by `Pulsar.Consumer`,
+which rejects what it does not know.
+
+All fifteen consumer options 1.x supported still exist under the same names, so a correctly
+spelled 1.x configuration carries over unchanged. A misspelled one now raises — which is the
+point.
+
+Two things to know:
+
+**Reserved keys raise.** The producer sets some options itself, and setting them in
+`:consumer_opts` would either be discarded or break its flow accounting. Each is rejected with
+the option that does work instead:
+
+`:client`, `:topic`, `:subscription_name`, `:callback_module`, `:init_args`, `:name`,
+`:consumer_count`, `:flow_policy`, `:flow_initial`, `:flow_threshold`, `:flow_refill`
+
+Use `producer: [concurrency: N]` for the consumer count, and the producer's own `:flow_initial`
+/ `:flow_threshold` / `:flow_refill` for flow control.
+
+**Setting `:consumer_opts` replaces the default rather than merging into it.** The default is
+`[subscription_type: :shared]`, which is also `Pulsar.Consumer`'s own default, so in practice
+nothing is lost — but spell out every option you want in a single list rather than expecting a
+merge.
+
+## Message metadata
+
+1.x exposed the wire protocol structs directly, which meant knowing that a batched message
+carries its key in `single_metadata` while a non-batched one carries it in `metadata`. 2.0
+gives you normalized fields that answer the same way regardless of how the message was
+delivered, and keeps the protocol structs under `:raw`.
+
+```elixir
+# 1.x
+%{message_id: id, command: cmd, metadata: md, single_metadata: smd, broker_metadata: bmd} =
+  message.metadata
+
+# 2.0
+%{command: cmd, metadata: md, single_metadata: smd, broker_metadata: bmd} = message.metadata.raw
+```
+
+`:message_id` keeps its name and its opaque role. The four protocol keys move under `:raw`.
+Everything else is new:
+
+`:message_id_string`, `:topic`, `:base_topic`, `:partition`, `:subscription`, `:key`,
+`:ordering_key`, `:properties`, `:producer_name`, `:publish_time`, `:event_time`,
+`:redelivery_count`
+
+Prefer these over `:raw`, whose shape follows the wire protocol and is explicitly unstable.
+Reading the key off a batched message, for instance, is now just `message.metadata.key`.
+
+```elixir
+def handle_message(_processor, message, _context) do
+  %{topic: topic, partition: partition, key: key, properties: properties} = message.metadata
+  message
+end
+```
+
+## Behaviour changes that need no code change
+
+These do not require edits, but they change what you will observe.
+
+**Consumer ownership.** Each producer stage now starts and links its own consumer roots
+instead of registering them under the client's `DynamicSupervisor`. A consumer that dies takes
+its stage down and Broadway recreates both, where 1.x could leave a stage running with nothing
+to consume. One consequence: `Pulsar.Client.consumers/1` no longer lists a pipeline's
+consumers. Stop the Broadway pipeline to stop them.
+
+**Acknowledgement failures no longer crash the pipeline.** 1.x asserted `:ok = Pulsar.ack(...)`,
+so any ack failure raised inside Broadway's acknowledger and aborted the rest of that batch's
+acknowledgements. 2.0 logs and continues.
+
+**Incomplete chunked and invalid messages are acknowledged and dropped.** In 1.x an incomplete
+chunked message was filtered out of the producer buffer but never acknowledged, so it held the
+subscription's cursor. Both cases are now logged, acked and dropped before reaching the
+pipeline.
+
+**Consumers subscribe immediately by default.** pulsar-elixir 3.x defaults `:startup_delay_ms`
+and `:startup_jitter_ms` to `0`, where 2.x defaulted both to `1000`. If you relied on that
+stagger across a large fleet of restarting consumers, set them explicitly in `:consumer_opts`.
+
+## Worth checking while you are here
+
+Neither of these changed in 2.0, but both are easy to get wrong and easy to fix during an
+upgrade.
+
+**`Broadway.Message.failed/2` does nothing without `:redelivery_interval`.** A negative
+acknowledgement is only redelivered when the consumer has a redelivery interval configured;
+without one the message is not retried, and if it arrived in a batch its entry stays
+unacknowledged until something acks it or the consumer restarts. If your pipeline marks
+messages as failed and expects them back, set it:
+
+```elixir
+consumer_opts: [subscription_type: :shared, redelivery_interval: 60_000]
+```
+
+**Consider `:batch_index_ack_enabled` if your topics are batched.** Pulsar producers batch by
+default, and an acknowledgement names the entry it lands in, not the message. Broadway
+routinely completes messages from one entry out of order and in different batches, so one
+failed message causes its whole entry to be redelivered — and its already-successful siblings
+to be processed a second time. Enabling batch index acknowledgement narrows redelivery to just
+the messages that actually failed:
+
+```elixir
+consumer_opts: [subscription_type: :shared, batch_index_ack_enabled: true]
+```
+
+It requires `acknowledgmentAtBatchIndexLevelEnabled=true` on the broker — Pulsar's shipped
+`broker.conf` enables it, `standalone.conf` does not — and costs one acknowledgement command
+per message rather than one per entry. Nothing in the protocol reports the broker setting, so
+enabling it against a broker that ignores it will acknowledge whole entries and lose the
+messages batched alongside an acked one. Verify the broker first.
+
+## Complete example
+
+```elixir
+# 1.x
+defmodule MyApp.PulsarPipeline do
+  use Broadway
+
+  def start_link(_opts) do
+    Broadway.start_link(__MODULE__,
+      name: __MODULE__,
+      producer: [
+        module: {OffBroadway.Pulsar.Producer,
+          host: "pulsar://localhost:6650",
+          topic: "persistent://public/default/my-topic",
+          subscription: "my-subscription",
+          consumer_opts: [subscription_type: :Shared, initial_position: :earliest]
+        },
+        concurrency: 1
+      ],
+      processors: [default: [concurrency: 10]]
+    )
+  end
+
+  @impl true
+  def handle_message(_processor, message, _context) do
+    key = message.metadata.single_metadata && message.metadata.single_metadata.partition_key
+    IO.inspect({key, message.data})
+    message
+  end
+end
+```
+
+```elixir
+# 2.0
+children = [
+  {Pulsar.Client, host: "pulsar://localhost:6650"},
+  MyApp.PulsarPipeline
+]
+
+defmodule MyApp.PulsarPipeline do
+  use Broadway
+
+  def start_link(_opts) do
+    Broadway.start_link(__MODULE__,
+      name: __MODULE__,
+      producer: [
+        module: {OffBroadway.Pulsar.Producer,
+          topics: ["persistent://public/default/my-topic"],
+          subscription: "my-subscription",
+          consumer_opts: [subscription_type: :shared, initial_position: :earliest]
+        },
+        concurrency: 1
+      ],
+      processors: [default: [concurrency: 10]]
+    )
+  end
+
+  @impl true
+  def handle_message(_processor, message, _context) do
+    IO.inspect({message.metadata.key, message.data})
+    message
+  end
+end
+```
+
+See the
+[producer documentation](https://hexdocs.pm/off_broadway_pulsar/OffBroadway.Pulsar.Producer.html#start_link/1)
+for every option with its type and default.

--- a/lib/off_broadway/pulsar/producer.ex
+++ b/lib/off_broadway/pulsar/producer.ex
@@ -390,6 +390,12 @@ defmodule OffBroadway.Pulsar.Producer do
     end
   end
 
+  def handle_info(message, state) do
+    Logger.warning("Producer received an unexpected message: #{inspect(message)}")
+
+    {:noreply, [], state}
+  end
+
   @impl GenStage
   def terminate(_reason, state) do
     Enum.each(state.consumer_roots, fn {root, _metadata} ->

--- a/lib/off_broadway/pulsar/producer.ex
+++ b/lib/off_broadway/pulsar/producer.ex
@@ -325,7 +325,7 @@ defmodule OffBroadway.Pulsar.Producer do
       demand: 0,
       # An ordered mix of {:message, %Pulsar.Message{}, consumer_pid, context} and
       # {:permits, consumer_pid, consumed} markers. See take_dispatchable/3.
-      buffer: [],
+      buffer: :queue.new(),
       flow_initial: flow_initial,
       flow_threshold: flow_threshold,
       flow_refill: flow_refill
@@ -339,7 +339,7 @@ defmodule OffBroadway.Pulsar.Producer do
   @impl GenStage
   def handle_demand(incoming_demand, state) do
     new_demand = state.demand + incoming_demand
-    Logger.debug("Received demand #{incoming_demand}, total demand: #{new_demand}, buffer: #{length(state.buffer)}")
+    Logger.debug("Received demand #{incoming_demand}, total demand: #{new_demand}, buffer: #{:queue.len(state.buffer)}")
     dispatch_messages(%{state | demand: new_demand})
   end
 
@@ -354,14 +354,15 @@ defmodule OffBroadway.Pulsar.Producer do
   end
 
   def handle_info({:pulsar_message, message_info, consumer_pid, context}, state) do
-    new_buffer = state.buffer ++ [{:message, message_info, consumer_pid, context}]
-    Logger.debug("Message arrived, buffer size: #{length(new_buffer)}")
+    new_buffer = :queue.in({:message, message_info, consumer_pid, context}, state.buffer)
+    Logger.debug("Message arrived, buffer size: #{:queue.len(new_buffer)}")
 
     dispatch_messages(%{state | buffer: new_buffer})
   end
 
   def handle_info({:permits_consumed, consumer_pid, consumed}, state) do
-    dispatch_messages(%{state | buffer: state.buffer ++ [{:permits, consumer_pid, consumed}]})
+    buffer = :queue.in({:permits, consumer_pid, consumed}, state.buffer)
+    dispatch_messages(%{state | buffer: buffer})
   end
 
   def handle_info({:DOWN, monitor_ref, :process, pid, reason}, state) do
@@ -400,11 +401,14 @@ defmodule OffBroadway.Pulsar.Producer do
     # Entries from a dead worker can no longer be acknowledged; discard them and
     # their permit markers.
     buffer =
-      Enum.reject(state.buffer, fn
-        {:message, _msg, ^consumer_pid, _context} -> true
-        {:permits, ^consumer_pid, _consumed} -> true
-        _entry -> false
-      end)
+      :queue.filter(
+        fn
+          {:message, _msg, ^consumer_pid, _context} -> false
+          {:permits, ^consumer_pid, _consumed} -> false
+          _entry -> true
+        end,
+        state.buffer
+      )
 
     {:noreply, [],
      %{
@@ -418,7 +422,7 @@ defmodule OffBroadway.Pulsar.Producer do
     {taken, remaining} = take_dispatchable(buffer, demand)
     broadway_messages = for {:message, msg, pid, context} <- taken, do: wrap_message(msg, pid, context)
 
-    Logger.debug("Dispatching #{length(broadway_messages)} messages, #{length(remaining)} remaining in buffer")
+    Logger.debug("Dispatching #{length(broadway_messages)} messages, #{:queue.len(remaining)} remaining in buffer")
 
     state = charge_permits(%{state | buffer: remaining, demand: demand - length(broadway_messages)}, taken)
 
@@ -428,17 +432,21 @@ defmodule OffBroadway.Pulsar.Producer do
   # Permit markers follow all messages from the same broker delivery. Charge the delivery
   # only after those messages leave the buffer; a leading marker represents a delivery
   # that produced no Broadway messages.
-  defp take_dispatchable(buffer, demand, taken \\ [])
+  defp take_dispatchable(buffer, demand, taken \\ []) do
+    case :queue.out(buffer) do
+      {:empty, buffer} ->
+        {Enum.reverse(taken), buffer}
 
-  defp take_dispatchable([{:permits, _, _} = marker | rest], demand, taken) do
-    take_dispatchable(rest, demand, [marker | taken])
+      {{:value, {:permits, _, _} = marker}, rest} ->
+        take_dispatchable(rest, demand, [marker | taken])
+
+      {{:value, {:message, _, _, _} = message}, rest} when demand > 0 ->
+        take_dispatchable(rest, demand - 1, [message | taken])
+
+      {{:value, entry}, rest} ->
+        {Enum.reverse(taken), :queue.in_r(entry, rest)}
+    end
   end
-
-  defp take_dispatchable([{:message, _, _, _} = message | rest], demand, taken) when demand > 0 do
-    take_dispatchable(rest, demand - 1, [message | taken])
-  end
-
-  defp take_dispatchable(buffer, _demand, taken), do: {Enum.reverse(taken), buffer}
 
   defp charge_permits(state, taken) do
     Enum.reduce(taken, state, fn

--- a/lib/off_broadway/pulsar/producer.ex
+++ b/lib/off_broadway/pulsar/producer.ex
@@ -87,8 +87,12 @@ defmodule OffBroadway.Pulsar.Producer do
       flow control.
 
       `:batch_index_ack_enabled` is worth enabling for Broadway, which routinely completes
-      messages from one batch out of order, but it requires
-      `acknowledgmentAtBatchIndexLevelEnabled=true` on the broker.
+      messages from one batch out of order: without it a failed message takes its whole entry
+      back, and the siblings Broadway already handled are delivered again. It needs
+      `acknowledgmentAtBatchIndexLevelEnabled` on the broker, which is the Pulsar 4.2 default.
+
+      A nacked message is redelivered only when `:redelivery_interval` is set. Left unset, a
+      message the pipeline fails is not retried.
       """
     ],
     flow_initial: [
@@ -119,14 +123,12 @@ defmodule OffBroadway.Pulsar.Producer do
 
   #{NimbleOptions.docs(@opts_schema)}
 
-  Options are validated in `c:Broadway.Producer.prepare_for_start/2`, which runs once in the
-  Broadway process before any stage starts, so `Broadway.start_link/2` raises the
-  configuration error itself rather than leaving each stage to crash-loop under its supervisor
-  until the pipeline gives up. They are validated again in `c:GenStage.init/1`, which also
-  covers starting this producer outside a Broadway pipeline.
+  Options are validated in `c:Broadway.Producer.prepare_for_start/2`, which runs before any
+  stage starts, so `Broadway.start_link/2` raises the configuration error itself rather than
+  each stage crash-looping under its supervisor. They are validated again in
+  `c:GenStage.init/1`, which also covers starting this producer outside a Broadway pipeline.
 
-  That the client is running is checked per stage rather than once, since a stage that
-  restarts has to find it again.
+  The client is checked per stage instead, since a stage that restarts has to find it again.
 
   ## Flow Control
 
@@ -256,10 +258,8 @@ defmodule OffBroadway.Pulsar.Producer do
     GenStage.start_link(__MODULE__, opts)
   end
 
-  # Broadway runs this in its own process before starting the topology, so a configuration
-  # error is raised by Broadway.start_link/2 with the caller's stacktrace instead of being
-  # reported once per stage as a supervisor restart. It starts no children of its own: the
-  # consumers belong to the stages that feed on them, not to the pipeline.
+  # No children of its own: the consumers belong to the stages that feed on them, not to the
+  # pipeline.
   @impl Broadway.Producer
   def prepare_for_start(_module, broadway_opts) do
     {_producer_module, producer_opts} = broadway_opts[:producer][:module]

--- a/lib/off_broadway/pulsar/producer.ex
+++ b/lib/off_broadway/pulsar/producer.ex
@@ -16,16 +16,15 @@ defmodule OffBroadway.Pulsar.Producer do
   See `start_link/1` for detailed configuration options.
   """
 
+  @behaviour Broadway.Producer
+
   use GenStage
 
   alias Broadway.Message
   alias OffBroadway.Pulsar.Consumer, as: Callback
+  alias Pulsar.Consumer.Options
 
   require Logger
-
-  @default_consumer_opts [
-    subscription_type: :shared
-  ]
 
   # Keys the producer sets on every consumer it starts. A value given here would be silently
   # discarded by the merge below, or would break the producer's own flow accounting.
@@ -77,11 +76,11 @@ defmodule OffBroadway.Pulsar.Producer do
     ],
     consumer_opts: [
       type: :keyword_list,
-      default: @default_consumer_opts,
+      default: [subscription_type: :shared],
       doc: """
       Options forwarded to `Pulsar.Consumer.start_link/1`, applied to every topic. They are
-      documented and validated by `Pulsar.Consumer`, which rejects unknown keys. Setting this
-      replaces the default rather than merging into it.
+      documented and validated by `Pulsar.Consumer`, which rejects unknown keys and applies its
+      own defaults to whatever is left out — including `subscription_type: :shared`.
 
       The keys the producer sets itself are rejected here: #{@reserved_keys_doc}. Use
       `producer: [concurrency: N]` for the consumer count and the `:flow_*` options above for
@@ -120,8 +119,14 @@ defmodule OffBroadway.Pulsar.Producer do
 
   #{NimbleOptions.docs(@opts_schema)}
 
-  Options are validated when the stage starts, so a misconfigured pipeline fails at boot
-  rather than at the first message.
+  Options are validated in `c:Broadway.Producer.prepare_for_start/2`, which runs once in the
+  Broadway process before any stage starts, so `Broadway.start_link/2` raises the
+  configuration error itself rather than leaving each stage to crash-loop under its supervisor
+  until the pipeline gives up. They are validated again in `c:GenStage.init/1`, which also
+  covers starting this producer outside a Broadway pipeline.
+
+  That the client is running is checked per stage rather than once, since a stage that
+  restarts has to find it again.
 
   ## Flow Control
 
@@ -251,6 +256,19 @@ defmodule OffBroadway.Pulsar.Producer do
     GenStage.start_link(__MODULE__, opts)
   end
 
+  # Broadway runs this in its own process before starting the topology, so a configuration
+  # error is raised by Broadway.start_link/2 with the caller's stacktrace instead of being
+  # reported once per stage as a supervisor restart. It starts no children of its own: the
+  # consumers belong to the stages that feed on them, not to the pipeline.
+  @impl Broadway.Producer
+  def prepare_for_start(_module, broadway_opts) do
+    {_producer_module, producer_opts} = broadway_opts[:producer][:module]
+
+    validate_options!(producer_opts)
+
+    {[], broadway_opts}
+  end
+
   @impl GenStage
   def init(opts) do
     opts = validate_options!(opts)
@@ -266,11 +284,6 @@ defmodule OffBroadway.Pulsar.Producer do
     flow_initial = Keyword.fetch!(opts, :flow_initial)
     flow_threshold = Keyword.fetch!(opts, :flow_threshold)
     flow_refill = Keyword.fetch!(opts, :flow_refill)
-
-    if flow_threshold >= flow_initial do
-      raise ArgumentError,
-            "flow_threshold (#{flow_threshold}) must be less than flow_initial (#{flow_initial})"
-    end
 
     # Each worker grants its own initial window on subscribe, so restarts and
     # late-discovered partitions come back with permits rather than waiting to be given
@@ -562,6 +575,14 @@ defmodule OffBroadway.Pulsar.Producer do
         {:error, error} -> raise ArgumentError, Exception.message(error)
       end
 
+    flow_initial = Keyword.fetch!(opts, :flow_initial)
+    flow_threshold = Keyword.fetch!(opts, :flow_threshold)
+
+    if flow_threshold >= flow_initial do
+      raise ArgumentError,
+            "flow_threshold (#{flow_threshold}) must be less than flow_initial (#{flow_initial})"
+    end
+
     consumer_opts = Keyword.fetch!(opts, :consumer_opts)
 
     Enum.each(@reserved_consumer_opts, fn {key, reason} ->
@@ -569,6 +590,18 @@ defmodule OffBroadway.Pulsar.Producer do
         raise ArgumentError, "invalid value for :consumer_opts: #{inspect(key)} cannot be set here, #{reason}"
       end
     end)
+
+    try do
+      Options.validate!(
+        Keyword.merge(
+          [topic: "validation", subscription_name: "validation", callback_module: Callback],
+          consumer_opts
+        )
+      )
+    rescue
+      error in NimbleOptions.ValidationError ->
+        reraise ArgumentError, Exception.message(error), __STACKTRACE__
+    end
 
     opts
   end

--- a/lib/off_broadway/pulsar/producer.ex
+++ b/lib/off_broadway/pulsar/producer.ex
@@ -328,7 +328,8 @@ defmodule OffBroadway.Pulsar.Producer do
       buffer: :queue.new(),
       flow_initial: flow_initial,
       flow_threshold: flow_threshold,
-      flow_refill: flow_refill
+      flow_refill: flow_refill,
+      draining: false
     }
 
     schedule_health_check()
@@ -377,6 +378,10 @@ defmodule OffBroadway.Pulsar.Producer do
     end
   end
 
+  # A group that loses its last worker while draining would otherwise stop a stage that is
+  # already shutting down, abandoning the messages Broadway is still finishing.
+  def handle_info(:check_consumers, %{draining: true} = state), do: {:noreply, [], state}
+
   def handle_info(:check_consumers, state) do
     case check_consumers(state) do
       :ok ->
@@ -394,6 +399,13 @@ defmodule OffBroadway.Pulsar.Producer do
     Logger.warning("Producer received an unexpected message: #{inspect(message)}")
 
     {:noreply, [], state}
+  end
+
+  # The consumers themselves stay up: the messages Broadway is draining acknowledge through the
+  # worker that delivered them, and would be redelivered if it went away first.
+  @impl Broadway.Producer
+  def prepare_for_draining(state) do
+    {:noreply, [], %{state | draining: true}}
   end
 
   @impl GenStage
@@ -468,7 +480,7 @@ defmodule OffBroadway.Pulsar.Producer do
         outstanding = max(outstanding - consumed, 0)
         state = %{state | consumers: Map.put(state.consumers, pid, {topic, outstanding})}
 
-        if outstanding <= state.flow_threshold do
+        if outstanding <= state.flow_threshold and not state.draining do
           refill_consumer(state, pid, topic, outstanding)
         else
           state

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,13 @@ defmodule OffBroadwayPulsar.MixProject do
       source_url: "https://github.com/efcasado/off_broadway_pulsar",
       docs: [
         main: "OffBroadway.Pulsar.Producer",
-        extras: ["README.md"]
+        extras: [
+          "README.md",
+          "docs/upgrading_to_2.0.md"
+        ],
+        groups_for_extras: [
+          Guides: ~r/docs\/.*/
+        ]
       ]
     ]
   end
@@ -64,7 +70,7 @@ defmodule OffBroadwayPulsar.MixProject do
   defp package do
     [
       name: "off_broadway_pulsar",
-      files: ~w(lib .formatter.exs mix.exs README.md LICENSE CHANGELOG.md),
+      files: ~w(lib docs/upgrading_to_2.0.md .formatter.exs mix.exs README.md LICENSE CHANGELOG.md),
       licenses: ~w(MIT),
       links: %{
         "GitHub" => "https://github.com/efcasado/off_broadway_pulsar",

--- a/mix.exs
+++ b/mix.exs
@@ -21,6 +21,7 @@ defmodule OffBroadwayPulsar.MixProject do
         main: "OffBroadway.Pulsar.Producer",
         extras: [
           "README.md",
+          "CHANGELOG.md",
           "docs/upgrading_to_2.0.md"
         ],
         groups_for_extras: [

--- a/test/integration/batch_ack_test.exs
+++ b/test/integration/batch_ack_test.exs
@@ -1,0 +1,136 @@
+defmodule OffBroadwayPulsar.Integration.BatchAckTest do
+  use ExUnit.Case, async: false
+
+  alias OffBroadwayPulsar.Test.Support.DummyPipeline
+  alias OffBroadwayPulsar.Test.Support.System
+
+  @moduletag :integration
+  @client :batch_ack_test_client
+  @topic "persistent://public/default/broadway-batch-index-ack"
+  @batch ["msg-1", "msg-2", "msg-3"]
+  @failing "msg-2"
+
+  @index_topic @topic <> "-index"
+  @entry_topic @topic <> "-entry"
+
+  setup_all do
+    :ok = System.create_topic(@index_topic)
+    :ok = System.create_topic(@entry_topic)
+
+    {:ok, _client_pid} = Pulsar.Client.start_link(name: @client, host: "pulsar://localhost:6650")
+
+    :ok
+  end
+
+  test "a failed message is redelivered without its batch siblings" do
+    produce_one_batch(@index_topic, :batch_index_ack_producer)
+
+    deliveries = run_pipeline(@index_topic, "batch-index-ack-sub", batch_index_ack_enabled: true)
+
+    assert_one_entry(deliveries)
+
+    assert tally(deliveries) == %{"msg-1" => 1, @failing => 2, "msg-3" => 1}
+  end
+
+  test "without batch index acking the whole entry is redelivered" do
+    produce_one_batch(@entry_topic, :entry_ack_producer)
+
+    deliveries = run_pipeline(@entry_topic, "entry-ack-sub", [])
+
+    assert_one_entry(deliveries)
+
+    assert tally(deliveries) == %{"msg-1" => 2, @failing => 2, "msg-3" => 2}
+  end
+
+  defp produce_one_batch(topic, name) do
+    {:ok, producer} =
+      Pulsar.Producer.start_link(
+        topic: topic,
+        client: @client,
+        name: name,
+        batch_enabled: true,
+        # Filling the batch is what flushes it, so the messages land in one entry.
+        batch_size: length(@batch),
+        flush_interval: 60_000
+      )
+
+    :ok = Pulsar.Producer.await_ready(producer)
+
+    # Pulsar.Producer.send/3 waits for the receipt, so a blocking caller would sit in a batch
+    # it never sends the rest of.
+    refs =
+      for payload <- @batch do
+        {:ok, ref} = Pulsar.Producer.send_async(producer, payload)
+        ref
+      end
+
+    for ref <- refs, do: {:ok, _message_id} = Pulsar.Producer.await(ref, 10_000)
+
+    :ok = Pulsar.Producer.stop(producer, client: @client)
+  end
+
+  defp run_pipeline(topic, subscription, extra_consumer_opts) do
+    test_pid = self()
+    {:ok, failed_once} = Agent.start_link(fn -> false end)
+
+    handler = fn message, _context ->
+      send(test_pid, {:handled, message.data, message.metadata.message_id_string})
+
+      if message.data == @failing and not Agent.get_and_update(failed_once, &{&1, true}) do
+        Broadway.Message.failed(message, "first attempt fails")
+      else
+        message
+      end
+    end
+
+    {:ok, _broadway} =
+      DummyPipeline.start_link(
+        test_pid: test_pid,
+        topics: [topic],
+        subscription: subscription,
+        client: @client,
+        handler: handler,
+        name: :"#{subscription}_pipeline",
+        consumer_opts:
+          Keyword.merge(
+            [initial_position: :earliest, redelivery_interval: 500],
+            extra_consumer_opts
+          )
+      )
+
+    collect_deliveries()
+  end
+
+  defp collect_deliveries(acc \\ []) do
+    receive do
+      {:handled, payload, message_id} -> collect_deliveries([{payload, message_id} | acc])
+    after
+      3_000 -> Enum.reverse(acc)
+    end
+  end
+
+  defp tally(deliveries) do
+    deliveries
+    |> Enum.map(fn {payload, _message_id} -> payload end)
+    |> Enum.frequencies()
+  end
+
+  # A test that silently stopped batching would prove nothing.
+  defp assert_one_entry(deliveries) do
+    ids = deliveries |> Enum.map(fn {_payload, message_id} -> message_id end) |> Enum.uniq()
+
+    entries =
+      ids
+      |> Enum.map(fn id -> id |> String.split(":") |> Enum.take(2) end)
+      |> Enum.uniq()
+
+    assert length(entries) == 1, "expected one batched entry, got ids: #{inspect(ids)}"
+
+    batch_indexes =
+      ids
+      |> Enum.map(fn id -> id |> String.split(":") |> List.last() end)
+      |> Enum.sort()
+
+    assert batch_indexes == ["0", "1", "2"], "expected batch indexes 0..2, got ids: #{inspect(ids)}"
+  end
+end

--- a/test/off_broadway/pulsar/producer_test.exs
+++ b/test/off_broadway/pulsar/producer_test.exs
@@ -91,6 +91,58 @@ defmodule OffBroadway.Pulsar.ProducerTest do
     end
   end
 
+  describe "prepare_for_start/2" do
+    defp broadway_opts(producer_opts) do
+      [
+        name: __MODULE__.Pipeline,
+        producer: [module: {Producer, producer_opts}, concurrency: 1],
+        processors: [default: [concurrency: 1]]
+      ]
+    end
+
+    test "raises before any stage starts, so Broadway.start_link/2 reports the error" do
+      assert_raise ArgumentError, ~r/required :subscription option not found/, fn ->
+        Producer.prepare_for_start(__MODULE__, broadway_opts(topics: ["t"]))
+      end
+    end
+
+    test "raises on a reserved :consumer_opts key" do
+      opts = broadway_opts(topics: ["t"], subscription: "s", consumer_opts: [flow_initial: 10])
+
+      assert_raise ArgumentError, ~r/:flow_initial cannot be set here/, fn ->
+        Producer.prepare_for_start(__MODULE__, opts)
+      end
+    end
+
+    test "raises on an invalid nested :consumer_opts value" do
+      opts = broadway_opts(topics: ["t"], subscription: "s", consumer_opts: [subscription_type: :Shared])
+
+      assert_raise ArgumentError, ~r/invalid value for :subscription_type option/, fn ->
+        Producer.prepare_for_start(__MODULE__, opts)
+      end
+    end
+
+    test "raises when the flow threshold is not less than the initial window" do
+      opts = broadway_opts(topics: ["t"], subscription: "s", flow_initial: 10, flow_threshold: 10)
+
+      assert_raise ArgumentError, ~r/flow_threshold \(10\) must be less than flow_initial \(10\)/, fn ->
+        Producer.prepare_for_start(__MODULE__, opts)
+      end
+    end
+
+    test "starts no children and returns the topology options unchanged" do
+      opts = broadway_opts(topics: ["t"], subscription: "s")
+
+      assert {[], ^opts} = Producer.prepare_for_start(__MODULE__, opts)
+    end
+
+    test "does not require the client to be running, which is the stage's own precondition" do
+      opts = broadway_opts(topics: ["t"], subscription: "s", client: :no_such_client)
+
+      assert {[], ^opts} = Producer.prepare_for_start(__MODULE__, opts)
+    end
+  end
+
   describe ":consumer_ready" do
     test "registers the worker with the window it granted itself" do
       assert {:noreply, [], new_state} =

--- a/test/off_broadway/pulsar/producer_test.exs
+++ b/test/off_broadway/pulsar/producer_test.exs
@@ -193,18 +193,19 @@ defmodule OffBroadway.Pulsar.ProducerTest do
       {:ok, alive} = start_supervised({StubConsumer, self()})
       dead = self()
 
-      buffer = [
-        {:message, @message, dead, @context},
-        {:message, @message, alive, @context},
-        {:permits, dead, 2}
-      ]
+      buffer =
+        :queue.from_list([
+          {:message, @message, dead, @context},
+          {:message, @message, alive, @context},
+          {:permits, dead, 2}
+        ])
 
       state = %{state() | buffer: buffer, demand: 0, consumers: %{dead => {"topic", 10}, alive => {"other", 10}}}
 
       assert {:noreply, [], new_state} =
                Producer.handle_info({:DOWN, make_ref(), :process, dead, :killed}, state)
 
-      assert new_state.buffer == [{:message, @message, alive, @context}]
+      assert :queue.to_list(new_state.buffer) == [{:message, @message, alive, @context}]
       refute Map.has_key?(new_state.consumers, dead)
     end
   end
@@ -216,20 +217,24 @@ defmodule OffBroadway.Pulsar.ProducerTest do
 
       assert metadata.message_id_string == "1:2:-1"
       assert metadata.topic == "topic"
-      assert new_state.buffer == []
+      assert :queue.is_empty(new_state.buffer)
       # Nothing is charged until the flow policy reports what the delivery cost.
       pid = self()
       assert %{^pid => {"topic", 10}} = new_state.consumers
     end
 
     test "dispatches up to demand and buffers the rest" do
-      buffer = for _ <- 1..3, do: {:message, @message, self(), @context}
+      buffer =
+        1..3
+        |> Enum.map(fn _ -> {:message, @message, self(), @context} end)
+        |> :queue.from_list()
+
       state = %{state() | buffer: buffer, demand: 0}
 
       assert {:noreply, dispatched, new_state} = Producer.handle_demand(2, state)
 
       assert length(dispatched) == 2
-      assert length(new_state.buffer) == 1
+      assert :queue.len(new_state.buffer) == 1
       assert new_state.demand == 0
     end
   end
@@ -237,21 +242,22 @@ defmodule OffBroadway.Pulsar.ProducerTest do
   describe ":permits_consumed" do
     test "charges the window only once Broadway has taken the delivery's messages" do
       # One delivery: two messages, then the marker saying what the broker charged for it.
-      buffer = [
-        {:message, @message, self(), @context},
-        {:message, @message, self(), @context},
-        {:permits, self(), 2}
-      ]
+      buffer =
+        :queue.from_list([
+          {:message, @message, self(), @context},
+          {:message, @message, self(), @context},
+          {:permits, self(), 2}
+        ])
 
       pid = self()
 
       assert {:noreply, [_first], held} = Producer.handle_demand(1, %{state() | buffer: buffer, demand: 0})
       assert %{^pid => {"topic", 10}} = held.consumers
-      assert [{:message, _, _, _}, {:permits, _, 2}] = held.buffer
+      assert [{:message, _, _, _}, {:permits, _, 2}] = :queue.to_list(held.buffer)
 
       assert {:noreply, [_second], charged} = Producer.handle_demand(1, held)
       assert %{^pid => {"topic", 8}} = charged.consumers
-      assert charged.buffer == []
+      assert :queue.is_empty(charged.buffer)
     end
 
     test "charges a delivery no callback saw without waiting for demand" do
@@ -261,7 +267,7 @@ defmodule OffBroadway.Pulsar.ProducerTest do
 
       pid = self()
       assert %{^pid => {"topic", 8}} = new_state.consumers
-      assert new_state.buffer == []
+      assert :queue.is_empty(new_state.buffer)
     end
 
     test "refills once the window falls to the threshold" do
@@ -383,7 +389,7 @@ defmodule OffBroadway.Pulsar.ProducerTest do
       consumers: %{self() => {"topic", 10}},
       consumer_roots: %{},
       demand: 10,
-      buffer: [],
+      buffer: :queue.new(),
       flow_initial: 10,
       flow_threshold: 2,
       flow_refill: 5

--- a/test/off_broadway/pulsar/producer_test.exs
+++ b/test/off_broadway/pulsar/producer_test.exs
@@ -345,6 +345,41 @@ defmodule OffBroadway.Pulsar.ProducerTest do
     end
   end
 
+  describe "prepare_for_draining/1" do
+    test "marks the stage as draining without emitting anything" do
+      assert {:noreply, [], new_state} = Producer.prepare_for_draining(state())
+
+      assert new_state.draining
+    end
+
+    test "no more permits are granted once draining" do
+      {:ok, consumer} = start_supervised({StubConsumer, self()})
+
+      state = %{
+        state()
+        | consumers: %{consumer => {"topic", 3}},
+          flow_threshold: 2,
+          flow_refill: 5,
+          draining: true
+      }
+
+      assert {:noreply, [], new_state} = Producer.handle_info({:permits_consumed, consumer, 1}, state)
+
+      refute_receive {:send_flow, _permits}
+      assert %{^consumer => {"topic", 2}} = new_state.consumers
+    end
+
+    test "the health check does not stop a stage that is already shutting down" do
+      %{root: root, state: state} = healthy_consumer()
+
+      :ok = Agent.stop(worker(root))
+
+      draining = %{state | draining: true}
+
+      assert {:noreply, [], ^draining} = Producer.handle_info(:check_consumers, draining)
+    end
+  end
+
   describe "unexpected messages" do
     test "are ignored rather than taking the stage and its consumer roots down" do
       assert {:noreply, [], new_state} = Producer.handle_info(:unexpected, state())
@@ -409,7 +444,8 @@ defmodule OffBroadway.Pulsar.ProducerTest do
       buffer: :queue.new(),
       flow_initial: 10,
       flow_threshold: 2,
-      flow_refill: 5
+      flow_refill: 5,
+      draining: false
     }
   end
 end

--- a/test/off_broadway/pulsar/producer_test.exs
+++ b/test/off_broadway/pulsar/producer_test.exs
@@ -345,6 +345,23 @@ defmodule OffBroadway.Pulsar.ProducerTest do
     end
   end
 
+  describe "unexpected messages" do
+    test "are ignored rather than taking the stage and its consumer roots down" do
+      assert {:noreply, [], new_state} = Producer.handle_info(:unexpected, state())
+
+      assert new_state == state()
+    end
+
+    test "do not consume demand or disturb the buffer" do
+      buffered = %{state() | buffer: :queue.from_list([{:permits, self(), 1}]), demand: 7}
+
+      assert {:noreply, [], new_state} = Producer.handle_info({:some, :tuple}, buffered)
+
+      assert new_state.demand == 7
+      assert :queue.to_list(new_state.buffer) == [{:permits, self(), 1}]
+    end
+  end
+
   defp healthy_consumer(opts \\ []) do
     root = start_supervised!(consumer_root_spec(Keyword.get(opts, :worker_count, 1)))
     monitor_ref = Process.monitor(root)


### PR DESCRIPTION
## Summary

Prepares the Broadway Pulsar integration for the 2.0 release and makes producer startup and shutdown more predictable.

- Adds an upgrade guide covering the Pulsar client ownership change, option renames and validation, subscription atoms, consumer ownership, and normalized message metadata.
- Validates producer options in `prepare_for_start/2`, before Broadway starts any producer stage, including cross-option flow-window rules and nested `consumer_opts`.
- Preserves the existing `[subscription_type: :shared]` consumer default and includes the upgrade guide and changelog in generated and published documentation.
- Uses a queue for the producer message buffer so arrivals do not repeatedly copy the entire buffered list.
- Stops requesting new messages while the producer is draining and ignores unexpected messages instead of taking down the stage.
- Adds integration coverage for batch-index acknowledgements.

## Behaviour

| Area | Before | After |
| --- | --- | --- |
| Invalid producer configuration | Fails during stage initialization under Broadway's supervisor | `Broadway.start_link/2` raises during `prepare_for_start/2` |
| Invalid or unknown `:consumer_opts` keys | Deferred until a consumer stage starts | Validated before any stage starts |
| `:flow_threshold >= :flow_initial` | Deferred until producer initialization | Rejected during Broadway preparation |
| Producer message buffering | Appending to a list copies the existing buffer | Queue insertion is amortized O(1) while preserving FIFO order |
| Broadway shutdown | The producer could continue requesting messages while draining | New permits are not granted once draining begins |
| Unexpected producer messages | Could crash the stage | Ignored while preserving state |
| Batch acknowledgements | No integration coverage for batch-index acknowledgement | Covered with broker-level integration testing |

The upgrade guide is packaged with the project so the README link and generated documentation remain usable after publishing.

## Testing

- `producer_test.exs` — startup validation, nested consumer options, flow windows, queue buffering, draining, and unexpected messages.
- `batch_ack_test.exs` — integration coverage for batch-index acknowledgements.
- `docs/upgrading_to_2.0.md` — migration guidance for the changed connection, consumer, option, and metadata APIs.

The commits are intentionally kept focused so the migration documentation, validation changes, and performance/robustness changes remain independently reviewable.

## Verification

- `mix test test/off_broadway/pulsar/producer_test.exs` — 31 tests passing
- `mix format --check-formatted`
- `mix credo --strict`
